### PR TITLE
Bump golang and kind version

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.25.x
         - v1.26.x
         - v1.27.x
+        - v1.28.x
 
         test-suite:
         - ./test/conformance
@@ -43,10 +43,10 @@ jobs:
       CLUSTER_SUFFIX: c${{ github.run_id }}.local
 
     steps:
-    - name: Set up Go 1.20.x
+    - name: Set up Go 1.21.x
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Install Dependencies
       working-directory: ./


### PR DESCRIPTION
# Changes
- Bumps golang to version 1.21
- Bumps kind version range from 1.26-1.28

Fixes #1167
