### PR TITLE
Bump istio manifests to v1.19.0

### DIFF
--- a/third_party/istio-latest/generate-manifests.sh
+++ b/third_party/istio-latest/generate-manifests.sh
@@ -16,4 +16,4 @@
 
 source "$(dirname $0)/../library.sh"
 
-generate "1.18.0" "$(dirname $0)"
+generate "1.19.0" "$(dirname $0)"

--- a/third_party/istio-latest/istio-ci-ambient/istio.yaml
+++ b/third_party/istio-latest/istio-ci-ambient/istio.yaml
@@ -6,73 +6,64 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-cni
-  namespace: istio-system
   labels:
     app: istio-cni
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Cni
+    release: istio
+  name: istio-cni
+  namespace: istio-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-ingressgateway-service-account
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
     operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway-service-account
+  namespace: istio-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-reader-service-account
-  namespace: istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-service-account
+  namespace: istio-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app: istiod
+    release: istio
   name: istiod
   namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istiod-service-account
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
+  annotations: {}
+  labels: {}
   name: ztunnel
   namespace: istio-system
-  labels: {}
-  annotations: {}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-cni
   labels:
     app: istio-cni
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Cni
+    release: istio
+  name: istio-cni
 rules:
   - apiGroups:
       - ""
@@ -88,13 +79,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-cni-repair-role
   labels:
     app: istio-cni
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Cni
+    release: istio
+  name: istio-cni-repair-role
 rules:
   - apiGroups:
       - ""
@@ -123,10 +114,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-clusterrole-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-clusterrole-istio-system
 rules:
   - apiGroups:
       - config.istio.io
@@ -156,12 +147,21 @@ rules:
       - watch
   - apiGroups:
       - networking.istio.io
+    resources:
+      - workloadentries
     verbs:
       - get
       - watch
       - list
+  - apiGroups:
+      - networking.x-k8s.io
+      - gateway.networking.k8s.io
     resources:
-      - workloadentries
+      - gateways
+    verbs:
+      - get
+      - watch
+      - list
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -220,105 +220,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-istio-system
-  labels:
-    app: istio-reader
-    release: istio
-rules:
-  - apiGroups:
-      - config.istio.io
-      - security.istio.io
-      - networking.istio.io
-      - authentication.istio.io
-      - rbac.istio.io
-    resources:
-      - '*'
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - endpoints
-      - pods
-      - services
-      - nodes
-      - replicationcontrollers
-      - namespaces
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-    resources:
-      - workloadentries
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - replicasets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceexports
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceimports
-    verbs:
-      - get
-      - watch
-      - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istiod-clusterrole-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-clusterrole-istio-system
 rules:
   - apiGroups:
       - admissionregistration.k8s.io
@@ -347,26 +252,16 @@ rules:
       - rbac.istio.io
       - telemetry.istio.io
       - extensions.istio.io
-    verbs:
-      - get
-      - watch
-      - list
     resources:
       - '*'
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
       - list
-      - update
-      - patch
-      - create
-      - delete
+  - apiGroups:
+      - networking.istio.io
     resources:
       - workloadentries
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
@@ -375,8 +270,18 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - networking.istio.io
     resources:
       - workloadentries/status
+    verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -498,25 +403,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-gateway-controller-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-gateway-controller-istio-system
 rules:
   - apiGroups:
       - apps
-    verbs:
-      - get
-      - watch
-      - list
-      - update
-      - patch
-      - create
-      - delete
     resources:
       - deployments
-  - apiGroups:
-      - ""
     verbs:
       - get
       - watch
@@ -525,10 +420,10 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - ""
     resources:
       - services
-  - apiGroups:
-      - ""
     verbs:
       - get
       - watch
@@ -537,51 +432,10 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - ""
     resources:
       - serviceaccounts
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-rules:
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - mutatingwebhookconfigurations
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-      - patch
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - validatingwebhookconfigurations
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - config.istio.io
-      - security.istio.io
-      - networking.istio.io
-      - authentication.istio.io
-      - rbac.istio.io
-      - telemetry.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-    resources:
-      - '*'
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
@@ -590,167 +444,17 @@ rules:
       - patch
       - create
       - delete
-    resources:
-      - workloadentries
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-      - update
-      - patch
-      - create
-      - delete
-    resources:
-      - workloadentries/status
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-      - services
-      - namespaces
-      - endpoints
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-      - ingressclasses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses/status
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - certificates.k8s.io
-    resources:
-      - certificatesigningrequests
-      - certificatesigningrequests/approval
-      - certificatesigningrequests/status
-    verbs:
-      - update
-      - create
-      - get
-      - delete
-      - watch
-  - apiGroups:
-      - certificates.k8s.io
-    resources:
-      - signers
-    resourceNames:
-      - kubernetes.io/legacy-unknown
-    verbs:
-      - approve
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
-  - apiGroups:
-      - networking.x-k8s.io
-      - gateway.networking.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - networking.x-k8s.io
-      - gateway.networking.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - update
-  - apiGroups:
-      - gateway.networking.k8s.io
-    resources:
-      - gatewayclasses
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceexports
-    verbs:
-      - get
-      - watch
-      - list
-      - create
-      - delete
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceimports
-    verbs:
-      - get
-      - watch
-      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-cni
   labels:
     app: istio-cni
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Cni
+    release: istio
+  name: istio-cni
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -763,28 +467,28 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-cni-repair-rolebinding
   labels:
-    k8s-app: istio-cni-repair
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    k8s-app: istio-cni-repair
     operator.istio.io/component: Cni
-subjects:
-  - kind: ServiceAccount
-    name: istio-cni
-    namespace: istio-system
+  name: istio-cni-repair-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: istio-cni-repair-role
+subjects:
+  - kind: ServiceAccount
+    name: istio-cni
+    namespace: istio-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-clusterrole-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-clusterrole-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -797,26 +501,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-istio-system
-  labels:
-    app: istio-reader
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istio-reader-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istio-reader-service-account
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istiod-clusterrole-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-clusterrole-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -829,10 +517,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-gateway-controller-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-gateway-controller-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -840,34 +528,18 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istiod-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istiod-service-account
     namespace: istio-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
-  labels:
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
 rules:
   - apiGroups:
       - ""
@@ -881,18 +553,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod
+  namespace: istio-system
 rules:
   - apiGroups:
       - networking.istio.io
-    verbs:
-      - create
     resources:
       - gateways
+    verbs:
+      - create
   - apiGroups:
       - ""
     resources:
@@ -921,42 +593,15 @@ rules:
       - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: istiod-istio-system
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
-rules:
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - create
-    resources:
-      - gateways
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - get
-      - watch
-      - list
-      - update
-      - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
-  labels:
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -968,11 +613,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod
+  namespace: istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -980,23 +625,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: istiod-istio-system
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: istiod-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istiod-service-account
     namespace: istio-system
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -4304,7 +3932,7 @@ spec:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -4340,6 +3968,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -4416,7 +4045,7 @@ spec:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -4452,6 +4081,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -4487,10 +4117,10 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: istiooperators.install.istio.io
   labels:
     release: istio
     knative.dev/crd-install: "true"
+  name: istiooperators.install.istio.io
 spec:
   conversion:
     strategy: None
@@ -4499,10 +4129,10 @@ spec:
     kind: IstioOperator
     listKind: IstioOperatorList
     plural: istiooperators
-    singular: istiooperator
     shortNames:
       - iop
       - io
+    singular: istiooperator
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
@@ -4518,8 +4148,6 @@ spec:
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-      subresources:
-        status: {}
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -4527,6 +4155,8 @@ spec:
           x-kubernetes-preserve-unknown-fields: true
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5222,7 +4852,7 @@ spec:
                       tls:
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -5258,6 +4888,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -5391,7 +5022,7 @@ spec:
                       tls:
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -5427,6 +5058,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -6247,6 +5879,32 @@ spec:
                             format: double
                             type: number
                         type: object
+                      mirrors:
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            percentage:
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        type: array
                       name:
                         description: The name assigned to the route for debugging purposes.
                         type: string
@@ -6308,6 +5966,16 @@ spec:
                             type: string
                           uri:
                             type: string
+                          uriRegexRewrite:
+                            description: rewrite the path portion of the URI with the specified regex.
+                            properties:
+                              match:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                              rewrite:
+                                description: The string that should replace into matching portions of original URI.
+                                type: string
+                            type: object
                         type: object
                       route:
                         description: A HTTP rule can either return a direct_response, redirect or forward (default) traffic.
@@ -6974,6 +6642,32 @@ spec:
                             format: double
                             type: number
                         type: object
+                      mirrors:
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            percentage:
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        type: array
                       name:
                         description: The name assigned to the route for debugging purposes.
                         type: string
@@ -7035,6 +6729,16 @@ spec:
                             type: string
                           uri:
                             type: string
+                          uriRegexRewrite:
+                            description: rewrite the path portion of the URI with the specified regex.
+                            properties:
+                              match:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                              rewrite:
+                                description: The string that should replace into matching portions of original URI.
+                                type: string
+                            type: object
                         type: object
                       route:
                         description: A HTTP rule can either return a direct_response, redirect or forward (default) traffic.
@@ -7264,6 +6968,12 @@ spec:
             spec:
               description: 'Extend the functionality provided by the Istio proxy through WebAssembly filters. See more details at: https://istio.io/docs/reference/config/proxy_extensions/wasm-plugin.html'
               properties:
+                failStrategy:
+                  description: Specifies the failure behavior for the plugin due to fatal errors.
+                  enum:
+                    - FAIL_CLOSE
+                    - FAIL_OPEN
+                  type: string
                 imagePullPolicy:
                   enum:
                     - UNSPECIFIED_POLICY
@@ -7782,17 +7492,7 @@ spec:
         status: {}
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: istio
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
-    release: istio
 data:
-  meshNetworks: 'networks: {}'
   mesh: |-
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
@@ -7810,18 +7510,18 @@ data:
       prometheus: {}
     rootNamespace: istio-system
     trustDomain: cluster.local
----
+  meshNetworks: 'networks: {}'
 kind: ConfigMap
-apiVersion: v1
 metadata:
-  name: istio-cni-config
-  namespace: istio-system
   labels:
-    app: istio-cni
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Cni
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istio
+  namespace: istio-system
+---
+apiVersion: v1
 data:
   cni_network_config: |-
     {
@@ -7837,130 +7537,19 @@ data:
           "exclude_namespaces": [ "kube-system" ]
       }
     }
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
   labels:
-    istio.io/rev: default
+    app: istio-cni
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
+    istio.io/rev: default
+    operator.istio.io/component: Cni
     release: istio
+  name: istio-cni-config
+  namespace: istio-system
+---
+apiVersion: v1
 data:
-  values: |-
-    {
-      "global": {
-        "autoscalingv2API": true,
-        "caAddress": "",
-        "caName": "",
-        "certSigners": [],
-        "configCluster": false,
-        "configValidation": true,
-        "defaultNodeSelector": {},
-        "defaultPodDisruptionBudget": {
-          "enabled": true
-        },
-        "defaultResources": {
-          "requests": {
-            "cpu": "10m"
-          }
-        },
-        "enabled": true,
-        "externalIstiod": false,
-        "hub": "docker.io/istio",
-        "imagePullPolicy": "",
-        "imagePullSecrets": [],
-        "istioNamespace": "istio-system",
-        "istiod": {
-          "enableAnalysis": false
-        },
-        "jwtPolicy": "third-party-jwt",
-        "logAsJson": false,
-        "logging": {
-          "level": "default:info"
-        },
-        "meshID": "",
-        "meshNetworks": {},
-        "mountMtlsCerts": false,
-        "multiCluster": {
-          "clusterName": "",
-          "enabled": false
-        },
-        "namespace": "istio-system",
-        "network": "",
-        "omitSidecarInjectorConfigMap": false,
-        "oneNamespace": false,
-        "operatorManageWebhooks": false,
-        "pilotCertProvider": "istiod",
-        "priorityClassName": "",
-        "proxy": {
-          "autoInject": "enabled",
-          "clusterDomain": "cluster.local",
-          "componentLogLevel": "misc:error",
-          "enableCoreDump": false,
-          "excludeIPRanges": "",
-          "excludeInboundPorts": "",
-          "excludeOutboundPorts": "",
-          "image": "proxyv2",
-          "includeIPRanges": "*",
-          "includeInboundPorts": "*",
-          "includeOutboundPorts": "",
-          "logLevel": "warning",
-          "privileged": false,
-          "readinessFailureThreshold": 30,
-          "readinessInitialDelaySeconds": 1,
-          "readinessPeriodSeconds": 2,
-          "resources": {
-            "limits": {
-              "cpu": "2000m",
-              "memory": "1024Mi"
-            },
-            "requests": {
-              "cpu": "100m",
-              "memory": "128Mi"
-            }
-          },
-          "statusPort": 15020,
-          "tracer": "zipkin"
-        },
-        "proxy_init": {
-          "image": "proxyv2"
-        },
-        "remotePilotAddress": "",
-        "sds": {
-          "token": {
-            "aud": "istio-ca"
-          }
-        },
-        "sts": {
-          "servicePort": 0
-        },
-        "tag": "1.18.0",
-        "tracer": {
-          "datadog": {},
-          "lightstep": {},
-          "stackdriver": {},
-          "zipkin": {}
-        },
-        "useMCP": false,
-        "variant": ""
-      },
-      "istio_cni": {
-        "enabled": true
-      },
-      "revision": "",
-      "sidecarInjectorWebhook": {
-        "alwaysInjectSelector": [],
-        "defaultTemplates": [],
-        "enableNamespacesByDefault": false,
-        "injectedAnnotations": {},
-        "neverInjectSelector": [],
-        "rewriteAppHTTPProbe": true,
-        "templates": {}
-      }
-    }
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
     defaultTemplates: [sidecar]
@@ -7999,6 +7588,7 @@ data:
             {{- end }}
           {{- end }}
         {{- end }}
+        {{ $nativeSidecar := (eq (env "ENABLE_NATIVE_SIDECARS" "false") "true") }}
         {{- $containers := list }}
         {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
         metadata:
@@ -8021,7 +7611,7 @@ data:
             {{- end }}
         {{- if .Values.istio_cni.enabled }}
             {{- if not .Values.istio_cni.chained }}
-            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
+            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
             {{- end }}
             sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
             {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
@@ -8159,13 +7749,16 @@ data:
               runAsNonRoot: false
               runAsUser: 0
           {{ end }}
+          {{ if not $nativeSidecar }}
           containers:
+          {{ end }}
           - name: istio-proxy
           {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
             image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
           {{- else }}
             image: "{{ .ProxyImage }}"
           {{- end }}
+            {{ if $nativeSidecar }}restartPolicy: Always{{end}}
             ports:
             - containerPort: 15090
               protocol: TCP
@@ -8252,6 +7845,14 @@ data:
                 ]
             - name: ISTIO_META_APP_CONTAINERS
               value: "{{ $containers | join "," }}"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
             - name: ISTIO_META_NODE_NAME
@@ -8299,7 +7900,11 @@ data:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
+          {{ if $nativeSidecar }}
+            startupProbe:
+          {{ else }}
             readinessProbe:
+          {{ end }}
               httpGet:
                 path: /healthz/ready
                 port: 15021
@@ -8482,10 +8087,6 @@ data:
             - name: {{ . }}
             {{- end }}
           {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
-          {{- end }}
       gateway: |
         {{- $containers := list }}
         {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
@@ -8581,6 +8182,14 @@ data:
                   {{- end}}
                 {{- end}}
                 ]
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: ISTIO_META_APP_CONTAINERS
               value: "{{ $containers | join "," }}"
             - name: ISTIO_META_CLUSTER_ID
@@ -8719,10 +8328,6 @@ data:
             {{- range .Values.global.imagePullSecrets }}
             - name: {{ . }}
             {{- end }}
-          {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
           {{- end }}
       grpc-simple: |
         metadata:
@@ -9107,10 +8712,6 @@ data:
             - name: {{ . }}
             {{- end }}
           {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
-          {{- end }}
       waypoint: |
         apiVersion: v1
         kind: ServiceAccount
@@ -9164,7 +8765,17 @@ data:
               terminationGracePeriodSeconds: 2
               serviceAccountName: {{.ServiceAccount | quote}}
               containers:
-              - args:
+              - name: istio-proxy
+                ports:
+                - containerPort: 15021
+                  name: status-port
+                  protocol: TCP
+                - containerPort: 15090
+                  protocol: TCP
+                  name: http-envoy-prom
+                image: {{.ProxyImage}}
+                {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+                args:
                 - proxy
                 - waypoint
                 - --domain
@@ -9226,6 +8837,14 @@ data:
                 - name: PROXY_CONFIG
                   value: |
                          {{ protoToJSON .ProxyConfig }}
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                - name: GOMAXPROCS
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
                 - name: ISTIO_META_CLUSTER_ID
                   value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
                 - name: ISTIO_META_INTERCEPTION_MODE
@@ -9241,9 +8860,6 @@ data:
                 - name: ISTIO_META_MESH_ID
                   value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
                 {{- end }}
-                image: {{.ProxyImage}}
-                {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-                name: istio-proxy
                 resources:
                   limits:
                     cpu: "2"
@@ -9343,12 +8959,18 @@ data:
             uid: "{{.UID}}"
         spec:
           ports:
-          - name: https-hbone
-            port: 15008
+          {{- range $key, $val := .Ports }}
+          - name: {{ $val.Name | quote }}
+            port: {{ $val.Port }}
             protocol: TCP
-            appProtocol: https
+            appProtocol: {{ $val.AppProtocol }}
+          {{- end }}
           selector:
             istio.io/gateway-name: "{{.Name}}"
+          {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
+          loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
+          {{- end }}
+          type: {{ .ServiceType | quote }}
         ---
       kube-gateway: |
         apiVersion: v1
@@ -9407,6 +9029,10 @@ data:
               containers:
               - name: istio-proxy
                 image: "{{ .ProxyImage }}"
+                {{- if .Values.global.proxy.resources }}
+                resources:
+                  {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+                {{- end }}
                 {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
                 securityContext:
                 {{- if .KubeVersion122 }}
@@ -9502,6 +9128,14 @@ data:
                   value: "[]"
                 - name: ISTIO_META_APP_CONTAINERS
                   value: ""
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                - name: GOMAXPROCS
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
                 - name: ISTIO_META_CLUSTER_ID
                   value: "{{ valueOrDefault .Values.global.multiCluster.clusterName .ClusterID }}"
                 - name: ISTIO_META_NODE_NAME
@@ -9510,9 +9144,9 @@ data:
                       fieldPath: spec.nodeName
                 - name: ISTIO_META_INTERCEPTION_MODE
                   value: "{{ .ProxyConfig.InterceptionMode.String }}"
-                {{- if .Values.global.network }}
+                {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
                 - name: ISTIO_META_NETWORK
-                  value: "{{ .Values.global.network }}"
+                  value: {{.|quote}}
                 {{- end }}
                 - name: ISTIO_META_WORKLOAD_NAME
                   value: {{.DeploymentName|quote}}
@@ -9658,11 +9292,134 @@ data:
           {{- end }}
           selector:
             istio.io/gateway-name: {{.Name}}
-          {{- if .Spec.Addresses }}
+          {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
           loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
           {{- end }}
-          type: {{ index .Annotations "networking.istio.io/service-type" | default "LoadBalancer" | quote }}
+          type: {{ .ServiceType | quote }}
         ---
+  values: |-
+    {
+      "global": {
+        "autoscalingv2API": true,
+        "caAddress": "",
+        "caName": "",
+        "certSigners": [],
+        "configCluster": false,
+        "configValidation": true,
+        "defaultNodeSelector": {},
+        "defaultPodDisruptionBudget": {
+          "enabled": true
+        },
+        "defaultResources": {
+          "requests": {
+            "cpu": "10m"
+          }
+        },
+        "enabled": true,
+        "externalIstiod": false,
+        "hub": "docker.io/istio",
+        "imagePullPolicy": "",
+        "imagePullSecrets": [],
+        "istioNamespace": "istio-system",
+        "istiod": {
+          "enableAnalysis": false
+        },
+        "jwtPolicy": "third-party-jwt",
+        "logAsJson": false,
+        "logging": {
+          "level": "default:info"
+        },
+        "meshID": "",
+        "meshNetworks": {},
+        "mountMtlsCerts": false,
+        "multiCluster": {
+          "clusterName": "",
+          "enabled": false
+        },
+        "namespace": "istio-system",
+        "network": "",
+        "omitSidecarInjectorConfigMap": false,
+        "oneNamespace": false,
+        "operatorManageWebhooks": false,
+        "pilotCertProvider": "istiod",
+        "priorityClassName": "",
+        "proxy": {
+          "autoInject": "enabled",
+          "clusterDomain": "cluster.local",
+          "componentLogLevel": "misc:error",
+          "enableCoreDump": false,
+          "excludeIPRanges": "",
+          "excludeInboundPorts": "",
+          "excludeOutboundPorts": "",
+          "image": "proxyv2",
+          "includeIPRanges": "*",
+          "includeInboundPorts": "*",
+          "includeOutboundPorts": "",
+          "logLevel": "warning",
+          "privileged": false,
+          "readinessFailureThreshold": 30,
+          "readinessInitialDelaySeconds": 1,
+          "readinessPeriodSeconds": 2,
+          "resources": {
+            "limits": {
+              "cpu": "2000m",
+              "memory": "1024Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          },
+          "statusPort": 15020,
+          "tracer": "zipkin"
+        },
+        "proxy_init": {
+          "image": "proxyv2"
+        },
+        "remotePilotAddress": "",
+        "sds": {
+          "token": {
+            "aud": "istio-ca"
+          }
+        },
+        "sts": {
+          "servicePort": 0
+        },
+        "tag": "1.19.0",
+        "tracer": {
+          "datadog": {},
+          "lightstep": {},
+          "stackdriver": {},
+          "zipkin": {}
+        },
+        "useMCP": false,
+        "variant": ""
+      },
+      "istio_cni": {
+        "chained": true,
+        "enabled": true
+      },
+      "revision": "",
+      "sidecarInjectorWebhook": {
+        "alwaysInjectSelector": [],
+        "defaultTemplates": [],
+        "enableNamespacesByDefault": false,
+        "injectedAnnotations": {},
+        "neverInjectSelector": [],
+        "reinvocationPolicy": "Never",
+        "rewriteAppHTTPProbe": true,
+        "templates": {}
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istio-sidecar-injector
+  namespace: istio-system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -9778,7 +9535,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: docker.io/istio/proxyv2:1.18.0
+          image: docker.io/istio/proxyv2:1.19.0
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -9892,45 +9649,40 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istiod
+  namespace: istio-system
 spec:
+  selector:
+    matchLabels:
+      istio: pilot
   strategy:
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 25%
-  selector:
-    matchLabels:
-      istio: pilot
   template:
     metadata:
-      labels:
-        app: istiod
-        istio.io/rev: default
-        install.operator.istio.io/owning-resource: unknown
-        sidecar.istio.io/inject: "false"
-        operator.istio.io/component: Pilot
-        istio: pilot
       annotations:
+        ambient.istio.io/redirection: disabled
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
-        ambient.istio.io/redirection: disabled
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: istiod
+        install.operator.istio.io/owning-resource: unknown
+        istio: pilot
+        istio.io/rev: default
+        operator.istio.io/component: Pilot
         sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: istiod
-      securityContext:
-        fsGroup: 1337
       containers:
-        - name: discovery
-          image: docker.io/istio/pilot:1.18.0
-          args:
+        - args:
             - discovery
             - --monitoringAddr=:15014
             - --log_output_level=default:info
@@ -9938,20 +9690,6 @@ spec:
             - cluster.local
             - --keepaliveMaxServerConnectionAge
             - 30m
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-            - containerPort: 15010
-              protocol: TCP
-            - containerPort: 15017
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            initialDelaySeconds: 1
-            periodSeconds: 3
-            timeoutSeconds: 5
           env:
             - name: REVISION
               value: default
@@ -9988,10 +9726,6 @@ spec:
               value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"
-            - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
-              value: "true"
-            - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
-              value: "true"
             - name: ISTIOD_ADDR
               value: istiod.istio-system.svc:15012
             - name: PILOT_ENABLE_ANALYSIS
@@ -10002,37 +9736,62 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: PLATFORM
+              value: ""
+          image: docker.io/istio/pilot:1.19.0
+          name: discovery
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 15010
+              protocol: TCP
+            - containerPort: 15017
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            timeoutSeconds: 5
           resources:
             requests:
               cpu: 500m
               memory: 2048Mi
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1337
-            runAsGroup: 1337
-            runAsNonRoot: true
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
           volumeMounts:
-            - name: istio-token
-              mountPath: /var/run/secrets/tokens
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
               readOnly: true
-            - name: local-certs
-              mountPath: /var/run/secrets/istio-dns
-            - name: cacerts
-              mountPath: /etc/cacerts
+            - mountPath: /var/run/secrets/istio-dns
+              name: local-certs
+            - mountPath: /etc/cacerts
+              name: cacerts
               readOnly: true
-            - name: istio-kubeconfig
-              mountPath: /var/run/secrets/remote
+            - mountPath: /var/run/secrets/remote
+              name: istio-kubeconfig
               readOnly: true
-            - name: istio-csr-dns-cert
-              mountPath: /var/run/secrets/istiod/tls
+            - mountPath: /var/run/secrets/istiod/tls
+              name: istio-csr-dns-cert
               readOnly: true
-            - name: istio-csr-ca-configmap
-              mountPath: /var/run/secrets/istiod/ca
+            - mountPath: /var/run/secrets/istiod/ca
+              name: istio-csr-ca-configmap
               readOnly: true
+      securityContext:
+        fsGroup: 1337
+      serviceAccountName: istiod
       volumes:
         - emptyDir:
             medium: Memory
@@ -10046,40 +9805,36 @@ spec:
                   path: istio-token
         - name: cacerts
           secret:
-            secretName: cacerts
             optional: true
+            secretName: cacerts
         - name: istio-kubeconfig
           secret:
-            secretName: istio-kubeconfig
             optional: true
+            secretName: istio-kubeconfig
         - name: istio-csr-dns-cert
           secret:
+            optional: true
             secretName: istiod-tls
-            optional: true
-        - name: istio-csr-ca-configmap
-          configMap:
-            name: istio-ca-root-cert
+        - configMap:
             defaultMode: 420
+            name: istio-ca-root-cert
             optional: true
+          name: istio-csr-ca-configmap
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   annotations: null
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
-spec:
-  type: LoadBalancer
-  selector:
-    app: istio-ingressgateway
     istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
   ports:
     - name: status-port
       port: 15021
@@ -10093,33 +9848,37 @@ spec:
       port: 443
       protocol: TCP
       targetPort: 8443
+  selector:
+    app: istio-ingressgateway
+    istio: ingressgateway
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: istiod
+    install.operator.istio.io/owning-resource: unknown
+    istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
   name: istiod
   namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
-    app: istiod
-    istio: pilot
-    release: istio
 spec:
   ports:
-    - port: 15010
-      name: grpc-xds
+    - name: grpc-xds
+      port: 15010
       protocol: TCP
-    - port: 15012
-      name: https-dns
+    - name: https-dns
+      port: 15012
       protocol: TCP
-    - port: 443
-      name: https-webhook
+    - name: https-webhook
+      port: 443
+      protocol: TCP
       targetPort: 15017
-      protocol: TCP
-    - port: 15014
-      name: http-monitoring
+    - name: http-monitoring
+      port: 15014
       protocol: TCP
   selector:
     app: istiod
@@ -10128,41 +9887,41 @@ spec:
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Pilot
+    release: istio
+  name: istiod
+  namespace: istio-system
 spec:
   maxReplicas: 10
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 60
+          type: Utilization
+      type: Resource
   minReplicas: 3
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: istiod
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 60
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
     operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
@@ -10173,15 +9932,15 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: pilot
+    istio.io/rev: default
     operator.istio.io/component: Pilot
     release: istio
-    istio: pilot
+  name: istiod
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
@@ -10192,35 +9951,25 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: istio-sidecar-injector
   labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     app: sidecar-injector
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istio-sidecar-injector
 webhooks:
-  - name: rev.namespace.sidecar-injector.istio.io
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.namespace.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio.io/rev
@@ -10235,27 +9984,28 @@ webhooks:
           operator: NotIn
           values:
             - "false"
-  - name: rev.object.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.object.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio.io/rev
@@ -10272,27 +10022,28 @@ webhooks:
           operator: In
           values:
             - default
-  - name: namespace.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: namespace.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio-injection
@@ -10305,27 +10056,28 @@ webhooks:
           operator: NotIn
           values:
             - "false"
-  - name: object.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: object.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio-injection
@@ -10340,114 +10092,97 @@ webhooks:
             - "true"
         - key: istio.io/rev
           operator: DoesNotExist
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istio-validator-istio-system
   labels:
     app: istiod
-    release: istio
     istio: istiod
     istio.io/rev: default
+    release: istio
+  name: istio-validator-istio-system
 webhooks:
-  - name: rev.validation.istio.io
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /validate
-    rules:
-      - operations:
-          - CREATE
-          - UPDATE
-        apiGroups:
-          - security.istio.io
-          - networking.istio.io
-          - telemetry.istio.io
-          - extensions.istio.io
-        apiVersions:
-          - '*'
-        resources:
-          - '*'
     failurePolicy: Ignore
-    sideEffects: None
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.validation.istio.io
     objectSelector:
       matchExpressions:
         - key: istio.io/rev
           operator: In
           values:
             - default
+    rules:
+      - apiGroups:
+          - security.istio.io
+          - networking.istio.io
+          - telemetry.istio.io
+          - extensions.istio.io
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - '*'
+    sideEffects: None
 ---
-kind: DaemonSet
 apiVersion: apps/v1
+kind: DaemonSet
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    k8s-app: istio-cni-node
+    operator.istio.io/component: Cni
+    release: istio
   name: istio-cni-node
   namespace: istio-system
-  labels:
-    k8s-app: istio-cni-node
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Cni
 spec:
   selector:
     matchLabels:
       k8s-app: istio-cni-node
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
   template:
     metadata:
+      annotations:
+        ambient.istio.io/redirection: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "15014"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "false"
       labels:
         k8s-app: istio-cni-node
         sidecar.istio.io/inject: "false"
-      annotations:
-        sidecar.istio.io/inject: "false"
-        ambient.istio.io/redirection: disabled
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "15014"
-        prometheus.io/path: /metrics
     spec:
-      hostNetwork: true
-      nodeSelector:
-        kubernetes.io/os: linux
-      tolerations:
-        - effect: NoSchedule
-          operator: Exists
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
-      priorityClassName: system-node-critical
-      serviceAccountName: istio-cni
-      terminationGracePeriodSeconds: 5
       containers:
-        - name: install-cni
-          image: docker.io/istio/install-cni:1.18.0
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: 8000
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-            runAsNonRoot: false
-            privileged: true
+        - args:
+            - --log_output_level=default:info
           command:
             - install-cni
-          args:
-            - --log_output_level=default:info
           env:
             - name: CNI_NETWORK_CONFIG
               valueFrom:
                 configMapKeyRef:
-                  name: istio-cni-config
                   key: cni_network_config
+                  name: istio-cni-config
             - name: CNI_NET_DIR
               value: /etc/cni/net.d
             - name: CHAINED_CNI_PLUGIN
@@ -10481,6 +10216,29 @@ spec:
               value: info
             - name: AMBIENT_ENABLED
               value: "true"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          image: docker.io/istio/install-cni:1.19.0
+          name: install-cni
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          securityContext:
+            privileged: true
+            runAsGroup: 0
+            runAsNonRoot: false
+            runAsUser: 0
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
@@ -10489,59 +10247,16 @@ spec:
             - mountPath: /var/run/istio-cni
               name: cni-log-dir
             - mountPath: /etc/ambient-config
-              name: cni-ambientconfig
+              name: cni-ambient-config-dir
             - mountPath: /var/run/netns
               mountPropagation: HostToContainer
               name: cni-netns-dir
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
-      volumes:
-        - name: cni-bin-dir
-          hostPath:
-            path: /opt/cni/bin
-        - name: cni-ambientconfig
-          hostPath:
-            path: /etc/ambient-config
-        - name: cni-net-dir
-          hostPath:
-            path: /etc/cni/net.d
-        - name: cni-log-dir
-          hostPath:
-            path: /var/run/istio-cni
-        - name: cni-netns-dir
-          hostPath:
-            path: /var/run/netns
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: ztunnel
-  namespace: istio-system
-  labels: {}
-  annotations: {}
-spec:
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app: ztunnel
-  template:
-    metadata:
-      labels:
-        sidecar.istio.io/inject: "false"
-        app: ztunnel
-      annotations:
-        cni.projectcalico.org/allowedSourcePrefixes: '["0.0.0.0/0"]'
-        ambient.istio.io/redirection: disabled
-        sidecar.istio.io/inject: "false"
-        prometheus.io/port: "15020"
-        prometheus.io/scrape: "true"
-    spec:
-      serviceAccountName: ztunnel
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      serviceAccountName: istio-cni
+      terminationGracePeriodSeconds: 5
       tolerations:
         - effect: NoSchedule
           operator: Exists
@@ -10549,30 +10264,52 @@ spec:
           operator: Exists
         - effect: NoExecute
           operator: Exists
+      volumes:
+        - hostPath:
+            path: /opt/cni/bin
+          name: cni-bin-dir
+        - hostPath:
+            path: /etc/ambient-config
+          name: cni-ambient-config-dir
+        - hostPath:
+            path: /etc/cni/net.d
+          name: cni-net-dir
+        - hostPath:
+            path: /var/run/istio-cni
+          name: cni-log-dir
+        - hostPath:
+            path: /var/run/netns
+          name: cni-netns-dir
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations: {}
+  labels: {}
+  name: ztunnel
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      app: ztunnel
+  template:
+    metadata:
+      annotations:
+        ambient.istio.io/redirection: disabled
+        cni.projectcalico.org/allowedSourcePrefixes: '["0.0.0.0/0"]'
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: ztunnel
+        sidecar.istio.io/inject: "false"
+    spec:
       containers:
-        - name: istio-proxy
-          image: docker.io/istio/ztunnel:1.18.0
-          resources:
-            requests:
-              cpu: 500m
-              memory: 2048Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            privileged: false
-            capabilities:
-              drop:
-                - ALL
-              add:
-                - NET_ADMIN
-            readOnlyRootFilesystem: true
-            runAsGroup: 1337
-            runAsNonRoot: false
-            runAsUser: 0
-          readinessProbe:
-            httpGet:
-              port: 15021
-              path: /healthz/ready
-          args:
+        - args:
             - proxy
             - ztunnel
           env:
@@ -10598,19 +10335,60 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
+          image: docker.io/istio/ztunnel:1.19.0
+          name: istio-proxy
+          ports:
+            - containerPort: 15020
+              name: ztunnel-stats
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: 15021
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2048Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - NET_ADMIN
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1337
+            runAsNonRoot: false
+            runAsUser: 0
           volumeMounts:
             - mountPath: /var/run/secrets/istio
               name: istiod-ca-cert
             - mountPath: /var/run/secrets/tokens
               name: istio-token
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: ztunnel
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
       volumes:
         - name: istio-token
           projected:
             sources:
               - serviceAccountToken:
-                  path: istio-token
-                  expirationSeconds: 43200
                   audience: istio-ca
-        - name: istiod-ca-cert
-          configMap:
+                  expirationSeconds: 43200
+                  path: istio-token
+        - configMap:
             name: istio-ca-root-cert
+          name: istiod-ca-cert
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0

--- a/third_party/istio-latest/istio-ci-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-mesh/istio.yaml
@@ -6,50 +6,41 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-ingressgateway-service-account
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
     operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway-service-account
+  namespace: istio-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-reader-service-account
-  namespace: istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-service-account
+  namespace: istio-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app: istiod
+    release: istio
   name: istiod
   namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istiod-service-account
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-clusterrole-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-clusterrole-istio-system
 rules:
   - apiGroups:
       - config.istio.io
@@ -79,12 +70,21 @@ rules:
       - watch
   - apiGroups:
       - networking.istio.io
+    resources:
+      - workloadentries
     verbs:
       - get
       - watch
       - list
+  - apiGroups:
+      - networking.x-k8s.io
+      - gateway.networking.k8s.io
     resources:
-      - workloadentries
+      - gateways
+    verbs:
+      - get
+      - watch
+      - list
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -143,105 +143,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-istio-system
-  labels:
-    app: istio-reader
-    release: istio
-rules:
-  - apiGroups:
-      - config.istio.io
-      - security.istio.io
-      - networking.istio.io
-      - authentication.istio.io
-      - rbac.istio.io
-    resources:
-      - '*'
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - endpoints
-      - pods
-      - services
-      - nodes
-      - replicationcontrollers
-      - namespaces
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-    resources:
-      - workloadentries
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - replicasets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceexports
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceimports
-    verbs:
-      - get
-      - watch
-      - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istiod-clusterrole-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-clusterrole-istio-system
 rules:
   - apiGroups:
       - admissionregistration.k8s.io
@@ -270,26 +175,16 @@ rules:
       - rbac.istio.io
       - telemetry.istio.io
       - extensions.istio.io
-    verbs:
-      - get
-      - watch
-      - list
     resources:
       - '*'
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
       - list
-      - update
-      - patch
-      - create
-      - delete
+  - apiGroups:
+      - networking.istio.io
     resources:
       - workloadentries
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
@@ -298,8 +193,18 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - networking.istio.io
     resources:
       - workloadentries/status
+    verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -421,25 +326,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-gateway-controller-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-gateway-controller-istio-system
 rules:
   - apiGroups:
       - apps
-    verbs:
-      - get
-      - watch
-      - list
-      - update
-      - patch
-      - create
-      - delete
     resources:
       - deployments
-  - apiGroups:
-      - ""
     verbs:
       - get
       - watch
@@ -448,10 +343,10 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - ""
     resources:
       - services
-  - apiGroups:
-      - ""
     verbs:
       - get
       - watch
@@ -460,51 +355,10 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - ""
     resources:
       - serviceaccounts
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-rules:
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - mutatingwebhookconfigurations
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-      - patch
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - validatingwebhookconfigurations
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - config.istio.io
-      - security.istio.io
-      - networking.istio.io
-      - authentication.istio.io
-      - rbac.istio.io
-      - telemetry.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-    resources:
-      - '*'
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
@@ -513,164 +367,14 @@ rules:
       - patch
       - create
       - delete
-    resources:
-      - workloadentries
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-      - update
-      - patch
-      - create
-      - delete
-    resources:
-      - workloadentries/status
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-      - services
-      - namespaces
-      - endpoints
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-      - ingressclasses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses/status
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - certificates.k8s.io
-    resources:
-      - certificatesigningrequests
-      - certificatesigningrequests/approval
-      - certificatesigningrequests/status
-    verbs:
-      - update
-      - create
-      - get
-      - delete
-      - watch
-  - apiGroups:
-      - certificates.k8s.io
-    resources:
-      - signers
-    resourceNames:
-      - kubernetes.io/legacy-unknown
-    verbs:
-      - approve
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
-  - apiGroups:
-      - networking.x-k8s.io
-      - gateway.networking.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - networking.x-k8s.io
-      - gateway.networking.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - update
-  - apiGroups:
-      - gateway.networking.k8s.io
-    resources:
-      - gatewayclasses
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceexports
-    verbs:
-      - get
-      - watch
-      - list
-      - create
-      - delete
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceimports
-    verbs:
-      - get
-      - watch
-      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-clusterrole-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-clusterrole-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -683,26 +387,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-istio-system
-  labels:
-    app: istio-reader
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istio-reader-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istio-reader-service-account
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istiod-clusterrole-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-clusterrole-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -715,10 +403,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-gateway-controller-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-gateway-controller-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -726,34 +414,18 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istiod-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istiod-service-account
     namespace: istio-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
-  labels:
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
 rules:
   - apiGroups:
       - ""
@@ -767,18 +439,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod
+  namespace: istio-system
 rules:
   - apiGroups:
       - networking.istio.io
-    verbs:
-      - create
     resources:
       - gateways
+    verbs:
+      - create
   - apiGroups:
       - ""
     resources:
@@ -807,42 +479,15 @@ rules:
       - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: istiod-istio-system
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
-rules:
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - create
-    resources:
-      - gateways
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - get
-      - watch
-      - list
-      - update
-      - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
-  labels:
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -854,11 +499,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod
+  namespace: istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -866,23 +511,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: istiod-istio-system
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: istiod-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istiod-service-account
     namespace: istio-system
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -4190,7 +3818,7 @@ spec:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -4226,6 +3854,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -4302,7 +3931,7 @@ spec:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -4338,6 +3967,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -4373,10 +4003,10 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: istiooperators.install.istio.io
   labels:
     release: istio
     knative.dev/crd-install: "true"
+  name: istiooperators.install.istio.io
 spec:
   conversion:
     strategy: None
@@ -4385,10 +4015,10 @@ spec:
     kind: IstioOperator
     listKind: IstioOperatorList
     plural: istiooperators
-    singular: istiooperator
     shortNames:
       - iop
       - io
+    singular: istiooperator
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
@@ -4404,8 +4034,6 @@ spec:
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-      subresources:
-        status: {}
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -4413,6 +4041,8 @@ spec:
           x-kubernetes-preserve-unknown-fields: true
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5108,7 +4738,7 @@ spec:
                       tls:
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -5144,6 +4774,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -5277,7 +4908,7 @@ spec:
                       tls:
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -5313,6 +4944,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -6133,6 +5765,32 @@ spec:
                             format: double
                             type: number
                         type: object
+                      mirrors:
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            percentage:
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        type: array
                       name:
                         description: The name assigned to the route for debugging purposes.
                         type: string
@@ -6194,6 +5852,16 @@ spec:
                             type: string
                           uri:
                             type: string
+                          uriRegexRewrite:
+                            description: rewrite the path portion of the URI with the specified regex.
+                            properties:
+                              match:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                              rewrite:
+                                description: The string that should replace into matching portions of original URI.
+                                type: string
+                            type: object
                         type: object
                       route:
                         description: A HTTP rule can either return a direct_response, redirect or forward (default) traffic.
@@ -6860,6 +6528,32 @@ spec:
                             format: double
                             type: number
                         type: object
+                      mirrors:
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            percentage:
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        type: array
                       name:
                         description: The name assigned to the route for debugging purposes.
                         type: string
@@ -6921,6 +6615,16 @@ spec:
                             type: string
                           uri:
                             type: string
+                          uriRegexRewrite:
+                            description: rewrite the path portion of the URI with the specified regex.
+                            properties:
+                              match:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                              rewrite:
+                                description: The string that should replace into matching portions of original URI.
+                                type: string
+                            type: object
                         type: object
                       route:
                         description: A HTTP rule can either return a direct_response, redirect or forward (default) traffic.
@@ -7150,6 +6854,12 @@ spec:
             spec:
               description: 'Extend the functionality provided by the Istio proxy through WebAssembly filters. See more details at: https://istio.io/docs/reference/config/proxy_extensions/wasm-plugin.html'
               properties:
+                failStrategy:
+                  description: Specifies the failure behavior for the plugin due to fatal errors.
+                  enum:
+                    - FAIL_CLOSE
+                    - FAIL_OPEN
+                  type: string
                 imagePullPolicy:
                   enum:
                     - UNSPECIFIED_POLICY
@@ -7668,17 +7378,7 @@ spec:
         status: {}
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: istio
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
-    release: istio
 data:
-  meshNetworks: 'networks: {}'
   mesh: |-
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
@@ -7693,130 +7393,19 @@ data:
     enablePrometheusMerge: true
     rootNamespace: istio-system
     trustDomain: cluster.local
----
-apiVersion: v1
+  meshNetworks: 'networks: {}'
 kind: ConfigMap
 metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
   labels:
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Pilot
     release: istio
+  name: istio
+  namespace: istio-system
+---
+apiVersion: v1
 data:
-  values: |-
-    {
-      "global": {
-        "autoscalingv2API": true,
-        "caAddress": "",
-        "caName": "",
-        "certSigners": [],
-        "configCluster": false,
-        "configValidation": true,
-        "defaultNodeSelector": {},
-        "defaultPodDisruptionBudget": {
-          "enabled": true
-        },
-        "defaultResources": {
-          "requests": {
-            "cpu": "10m"
-          }
-        },
-        "enabled": true,
-        "externalIstiod": false,
-        "hub": "docker.io/istio",
-        "imagePullPolicy": "",
-        "imagePullSecrets": [],
-        "istioNamespace": "istio-system",
-        "istiod": {
-          "enableAnalysis": false
-        },
-        "jwtPolicy": "third-party-jwt",
-        "logAsJson": false,
-        "logging": {
-          "level": "default:info"
-        },
-        "meshID": "",
-        "meshNetworks": {},
-        "mountMtlsCerts": false,
-        "multiCluster": {
-          "clusterName": "",
-          "enabled": false
-        },
-        "namespace": "istio-system",
-        "network": "",
-        "omitSidecarInjectorConfigMap": false,
-        "oneNamespace": false,
-        "operatorManageWebhooks": false,
-        "pilotCertProvider": "istiod",
-        "priorityClassName": "",
-        "proxy": {
-          "autoInject": "enabled",
-          "clusterDomain": "cluster.local",
-          "componentLogLevel": "misc:error",
-          "enableCoreDump": false,
-          "excludeIPRanges": "",
-          "excludeInboundPorts": "",
-          "excludeOutboundPorts": "",
-          "image": "proxyv2",
-          "includeIPRanges": "*",
-          "includeInboundPorts": "*",
-          "includeOutboundPorts": "",
-          "logLevel": "warning",
-          "privileged": false,
-          "readinessFailureThreshold": 30,
-          "readinessInitialDelaySeconds": 1,
-          "readinessPeriodSeconds": 2,
-          "resources": {
-            "limits": {
-              "cpu": "2000m",
-              "memory": "1024Mi"
-            },
-            "requests": {
-              "cpu": "100m",
-              "memory": "128Mi"
-            }
-          },
-          "statusPort": 15020,
-          "tracer": "zipkin"
-        },
-        "proxy_init": {
-          "image": "proxyv2"
-        },
-        "remotePilotAddress": "",
-        "sds": {
-          "token": {
-            "aud": "istio-ca"
-          }
-        },
-        "sts": {
-          "servicePort": 0
-        },
-        "tag": "1.18.0",
-        "tracer": {
-          "datadog": {},
-          "lightstep": {},
-          "stackdriver": {},
-          "zipkin": {}
-        },
-        "useMCP": false,
-        "variant": ""
-      },
-      "istio_cni": {
-        "enabled": false
-      },
-      "revision": "",
-      "sidecarInjectorWebhook": {
-        "alwaysInjectSelector": [],
-        "defaultTemplates": [],
-        "enableNamespacesByDefault": false,
-        "injectedAnnotations": {},
-        "neverInjectSelector": [],
-        "rewriteAppHTTPProbe": true,
-        "templates": {}
-      }
-    }
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
     defaultTemplates: [sidecar]
@@ -7855,6 +7444,7 @@ data:
             {{- end }}
           {{- end }}
         {{- end }}
+        {{ $nativeSidecar := (eq (env "ENABLE_NATIVE_SIDECARS" "false") "true") }}
         {{- $containers := list }}
         {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
         metadata:
@@ -7877,7 +7467,7 @@ data:
             {{- end }}
         {{- if .Values.istio_cni.enabled }}
             {{- if not .Values.istio_cni.chained }}
-            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
+            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
             {{- end }}
             sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
             {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
@@ -8015,13 +7605,16 @@ data:
               runAsNonRoot: false
               runAsUser: 0
           {{ end }}
+          {{ if not $nativeSidecar }}
           containers:
+          {{ end }}
           - name: istio-proxy
           {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
             image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
           {{- else }}
             image: "{{ .ProxyImage }}"
           {{- end }}
+            {{ if $nativeSidecar }}restartPolicy: Always{{end}}
             ports:
             - containerPort: 15090
               protocol: TCP
@@ -8108,6 +7701,14 @@ data:
                 ]
             - name: ISTIO_META_APP_CONTAINERS
               value: "{{ $containers | join "," }}"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
             - name: ISTIO_META_NODE_NAME
@@ -8155,7 +7756,11 @@ data:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
+          {{ if $nativeSidecar }}
+            startupProbe:
+          {{ else }}
             readinessProbe:
+          {{ end }}
               httpGet:
                 path: /healthz/ready
                 port: 15021
@@ -8338,10 +7943,6 @@ data:
             - name: {{ . }}
             {{- end }}
           {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
-          {{- end }}
       gateway: |
         {{- $containers := list }}
         {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
@@ -8437,6 +8038,14 @@ data:
                   {{- end}}
                 {{- end}}
                 ]
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: ISTIO_META_APP_CONTAINERS
               value: "{{ $containers | join "," }}"
             - name: ISTIO_META_CLUSTER_ID
@@ -8575,10 +8184,6 @@ data:
             {{- range .Values.global.imagePullSecrets }}
             - name: {{ . }}
             {{- end }}
-          {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
           {{- end }}
       grpc-simple: |
         metadata:
@@ -8963,10 +8568,6 @@ data:
             - name: {{ . }}
             {{- end }}
           {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
-          {{- end }}
       waypoint: |
         apiVersion: v1
         kind: ServiceAccount
@@ -9020,7 +8621,17 @@ data:
               terminationGracePeriodSeconds: 2
               serviceAccountName: {{.ServiceAccount | quote}}
               containers:
-              - args:
+              - name: istio-proxy
+                ports:
+                - containerPort: 15021
+                  name: status-port
+                  protocol: TCP
+                - containerPort: 15090
+                  protocol: TCP
+                  name: http-envoy-prom
+                image: {{.ProxyImage}}
+                {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+                args:
                 - proxy
                 - waypoint
                 - --domain
@@ -9082,6 +8693,14 @@ data:
                 - name: PROXY_CONFIG
                   value: |
                          {{ protoToJSON .ProxyConfig }}
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                - name: GOMAXPROCS
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
                 - name: ISTIO_META_CLUSTER_ID
                   value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
                 - name: ISTIO_META_INTERCEPTION_MODE
@@ -9097,9 +8716,6 @@ data:
                 - name: ISTIO_META_MESH_ID
                   value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
                 {{- end }}
-                image: {{.ProxyImage}}
-                {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-                name: istio-proxy
                 resources:
                   limits:
                     cpu: "2"
@@ -9199,12 +8815,18 @@ data:
             uid: "{{.UID}}"
         spec:
           ports:
-          - name: https-hbone
-            port: 15008
+          {{- range $key, $val := .Ports }}
+          - name: {{ $val.Name | quote }}
+            port: {{ $val.Port }}
             protocol: TCP
-            appProtocol: https
+            appProtocol: {{ $val.AppProtocol }}
+          {{- end }}
           selector:
             istio.io/gateway-name: "{{.Name}}"
+          {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
+          loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
+          {{- end }}
+          type: {{ .ServiceType | quote }}
         ---
       kube-gateway: |
         apiVersion: v1
@@ -9263,6 +8885,10 @@ data:
               containers:
               - name: istio-proxy
                 image: "{{ .ProxyImage }}"
+                {{- if .Values.global.proxy.resources }}
+                resources:
+                  {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+                {{- end }}
                 {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
                 securityContext:
                 {{- if .KubeVersion122 }}
@@ -9358,6 +8984,14 @@ data:
                   value: "[]"
                 - name: ISTIO_META_APP_CONTAINERS
                   value: ""
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                - name: GOMAXPROCS
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
                 - name: ISTIO_META_CLUSTER_ID
                   value: "{{ valueOrDefault .Values.global.multiCluster.clusterName .ClusterID }}"
                 - name: ISTIO_META_NODE_NAME
@@ -9366,9 +9000,9 @@ data:
                       fieldPath: spec.nodeName
                 - name: ISTIO_META_INTERCEPTION_MODE
                   value: "{{ .ProxyConfig.InterceptionMode.String }}"
-                {{- if .Values.global.network }}
+                {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
                 - name: ISTIO_META_NETWORK
-                  value: "{{ .Values.global.network }}"
+                  value: {{.|quote}}
                 {{- end }}
                 - name: ISTIO_META_WORKLOAD_NAME
                   value: {{.DeploymentName|quote}}
@@ -9514,11 +9148,134 @@ data:
           {{- end }}
           selector:
             istio.io/gateway-name: {{.Name}}
-          {{- if .Spec.Addresses }}
+          {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
           loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
           {{- end }}
-          type: {{ index .Annotations "networking.istio.io/service-type" | default "LoadBalancer" | quote }}
+          type: {{ .ServiceType | quote }}
         ---
+  values: |-
+    {
+      "global": {
+        "autoscalingv2API": true,
+        "caAddress": "",
+        "caName": "",
+        "certSigners": [],
+        "configCluster": false,
+        "configValidation": true,
+        "defaultNodeSelector": {},
+        "defaultPodDisruptionBudget": {
+          "enabled": true
+        },
+        "defaultResources": {
+          "requests": {
+            "cpu": "10m"
+          }
+        },
+        "enabled": true,
+        "externalIstiod": false,
+        "hub": "docker.io/istio",
+        "imagePullPolicy": "",
+        "imagePullSecrets": [],
+        "istioNamespace": "istio-system",
+        "istiod": {
+          "enableAnalysis": false
+        },
+        "jwtPolicy": "third-party-jwt",
+        "logAsJson": false,
+        "logging": {
+          "level": "default:info"
+        },
+        "meshID": "",
+        "meshNetworks": {},
+        "mountMtlsCerts": false,
+        "multiCluster": {
+          "clusterName": "",
+          "enabled": false
+        },
+        "namespace": "istio-system",
+        "network": "",
+        "omitSidecarInjectorConfigMap": false,
+        "oneNamespace": false,
+        "operatorManageWebhooks": false,
+        "pilotCertProvider": "istiod",
+        "priorityClassName": "",
+        "proxy": {
+          "autoInject": "enabled",
+          "clusterDomain": "cluster.local",
+          "componentLogLevel": "misc:error",
+          "enableCoreDump": false,
+          "excludeIPRanges": "",
+          "excludeInboundPorts": "",
+          "excludeOutboundPorts": "",
+          "image": "proxyv2",
+          "includeIPRanges": "*",
+          "includeInboundPorts": "*",
+          "includeOutboundPorts": "",
+          "logLevel": "warning",
+          "privileged": false,
+          "readinessFailureThreshold": 30,
+          "readinessInitialDelaySeconds": 1,
+          "readinessPeriodSeconds": 2,
+          "resources": {
+            "limits": {
+              "cpu": "2000m",
+              "memory": "1024Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          },
+          "statusPort": 15020,
+          "tracer": "zipkin"
+        },
+        "proxy_init": {
+          "image": "proxyv2"
+        },
+        "remotePilotAddress": "",
+        "sds": {
+          "token": {
+            "aud": "istio-ca"
+          }
+        },
+        "sts": {
+          "servicePort": 0
+        },
+        "tag": "1.19.0",
+        "tracer": {
+          "datadog": {},
+          "lightstep": {},
+          "stackdriver": {},
+          "zipkin": {}
+        },
+        "useMCP": false,
+        "variant": ""
+      },
+      "istio_cni": {
+        "chained": true,
+        "enabled": false
+      },
+      "revision": "",
+      "sidecarInjectorWebhook": {
+        "alwaysInjectSelector": [],
+        "defaultTemplates": [],
+        "enableNamespacesByDefault": false,
+        "injectedAnnotations": {},
+        "neverInjectSelector": [],
+        "reinvocationPolicy": "Never",
+        "rewriteAppHTTPProbe": true,
+        "templates": {}
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istio-sidecar-injector
+  namespace: istio-system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -9632,7 +9389,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: docker.io/istio/proxyv2:1.18.0
+          image: docker.io/istio/proxyv2:1.19.0
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -9746,45 +9503,40 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istiod
+  namespace: istio-system
 spec:
+  selector:
+    matchLabels:
+      istio: pilot
   strategy:
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 25%
-  selector:
-    matchLabels:
-      istio: pilot
   template:
     metadata:
-      labels:
-        app: istiod
-        istio.io/rev: default
-        install.operator.istio.io/owning-resource: unknown
-        sidecar.istio.io/inject: "false"
-        operator.istio.io/component: Pilot
-        istio: pilot
       annotations:
+        ambient.istio.io/redirection: disabled
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
-        ambient.istio.io/redirection: disabled
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: istiod
+        install.operator.istio.io/owning-resource: unknown
+        istio: pilot
+        istio.io/rev: default
+        operator.istio.io/component: Pilot
         sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: istiod
-      securityContext:
-        fsGroup: 1337
       containers:
-        - name: discovery
-          image: docker.io/istio/pilot:1.18.0
-          args:
+        - args:
             - discovery
             - --monitoringAddr=:15014
             - --log_output_level=default:info
@@ -9792,20 +9544,6 @@ spec:
             - cluster.local
             - --keepaliveMaxServerConnectionAge
             - 30m
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-            - containerPort: 15010
-              protocol: TCP
-            - containerPort: 15017
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            initialDelaySeconds: 1
-            periodSeconds: 3
-            timeoutSeconds: 5
           env:
             - name: REVISION
               value: default
@@ -9832,10 +9570,6 @@ spec:
               value: /var/run/secrets/remote/config
             - name: PILOT_TRACE_SAMPLING
               value: "1"
-            - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
-              value: "true"
-            - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
-              value: "true"
             - name: ISTIOD_ADDR
               value: istiod.istio-system.svc:15012
             - name: PILOT_ENABLE_ANALYSIS
@@ -9846,37 +9580,62 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: PLATFORM
+              value: ""
+          image: docker.io/istio/pilot:1.19.0
+          name: discovery
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 15010
+              protocol: TCP
+            - containerPort: 15017
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            timeoutSeconds: 5
           resources:
             requests:
               cpu: 500m
               memory: 2048Mi
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1337
-            runAsGroup: 1337
-            runAsNonRoot: true
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
           volumeMounts:
-            - name: istio-token
-              mountPath: /var/run/secrets/tokens
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
               readOnly: true
-            - name: local-certs
-              mountPath: /var/run/secrets/istio-dns
-            - name: cacerts
-              mountPath: /etc/cacerts
+            - mountPath: /var/run/secrets/istio-dns
+              name: local-certs
+            - mountPath: /etc/cacerts
+              name: cacerts
               readOnly: true
-            - name: istio-kubeconfig
-              mountPath: /var/run/secrets/remote
+            - mountPath: /var/run/secrets/remote
+              name: istio-kubeconfig
               readOnly: true
-            - name: istio-csr-dns-cert
-              mountPath: /var/run/secrets/istiod/tls
+            - mountPath: /var/run/secrets/istiod/tls
+              name: istio-csr-dns-cert
               readOnly: true
-            - name: istio-csr-ca-configmap
-              mountPath: /var/run/secrets/istiod/ca
+            - mountPath: /var/run/secrets/istiod/ca
+              name: istio-csr-ca-configmap
               readOnly: true
+      securityContext:
+        fsGroup: 1337
+      serviceAccountName: istiod
       volumes:
         - emptyDir:
             medium: Memory
@@ -9890,40 +9649,36 @@ spec:
                   path: istio-token
         - name: cacerts
           secret:
-            secretName: cacerts
             optional: true
+            secretName: cacerts
         - name: istio-kubeconfig
           secret:
-            secretName: istio-kubeconfig
             optional: true
+            secretName: istio-kubeconfig
         - name: istio-csr-dns-cert
           secret:
+            optional: true
             secretName: istiod-tls
-            optional: true
-        - name: istio-csr-ca-configmap
-          configMap:
-            name: istio-ca-root-cert
+        - configMap:
             defaultMode: 420
+            name: istio-ca-root-cert
             optional: true
+          name: istio-csr-ca-configmap
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   annotations: null
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
-spec:
-  type: LoadBalancer
-  selector:
-    app: istio-ingressgateway
     istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
   ports:
     - name: status-port
       port: 15021
@@ -9937,33 +9692,37 @@ spec:
       port: 443
       protocol: TCP
       targetPort: 8443
+  selector:
+    app: istio-ingressgateway
+    istio: ingressgateway
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: istiod
+    install.operator.istio.io/owning-resource: unknown
+    istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
   name: istiod
   namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
-    app: istiod
-    istio: pilot
-    release: istio
 spec:
   ports:
-    - port: 15010
-      name: grpc-xds
+    - name: grpc-xds
+      port: 15010
       protocol: TCP
-    - port: 15012
-      name: https-dns
+    - name: https-dns
+      port: 15012
       protocol: TCP
-    - port: 443
-      name: https-webhook
+    - name: https-webhook
+      port: 443
+      protocol: TCP
       targetPort: 15017
-      protocol: TCP
-    - port: 15014
-      name: http-monitoring
+    - name: http-monitoring
+      port: 15014
       protocol: TCP
   selector:
     app: istiod
@@ -9972,41 +9731,41 @@ spec:
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Pilot
+    release: istio
+  name: istiod
+  namespace: istio-system
 spec:
   maxReplicas: 10
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 60
+          type: Utilization
+      type: Resource
   minReplicas: 3
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: istiod
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 60
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
     operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
@@ -10017,15 +9776,15 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: pilot
+    istio.io/rev: default
     operator.istio.io/component: Pilot
     release: istio
-    istio: pilot
+  name: istiod
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
@@ -10036,35 +9795,25 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: istio-sidecar-injector
   labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     app: sidecar-injector
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istio-sidecar-injector
 webhooks:
-  - name: rev.namespace.sidecar-injector.istio.io
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.namespace.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio.io/rev
@@ -10079,27 +9828,28 @@ webhooks:
           operator: NotIn
           values:
             - "false"
-  - name: rev.object.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.object.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio.io/rev
@@ -10116,27 +9866,28 @@ webhooks:
           operator: In
           values:
             - default
-  - name: namespace.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: namespace.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio-injection
@@ -10149,27 +9900,28 @@ webhooks:
           operator: NotIn
           values:
             - "false"
-  - name: object.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: object.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio-injection
@@ -10184,47 +9936,58 @@ webhooks:
             - "true"
         - key: istio.io/rev
           operator: DoesNotExist
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istio-validator-istio-system
   labels:
     app: istiod
-    release: istio
     istio: istiod
     istio.io/rev: default
+    release: istio
+  name: istio-validator-istio-system
 webhooks:
-  - name: rev.validation.istio.io
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /validate
-    rules:
-      - operations:
-          - CREATE
-          - UPDATE
-        apiGroups:
-          - security.istio.io
-          - networking.istio.io
-          - telemetry.istio.io
-          - extensions.istio.io
-        apiVersions:
-          - '*'
-        resources:
-          - '*'
     failurePolicy: Ignore
-    sideEffects: None
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.validation.istio.io
     objectSelector:
       matchExpressions:
         - key: istio.io/rev
           operator: In
           values:
             - default
+    rules:
+      - apiGroups:
+          - security.istio.io
+          - networking.istio.io
+          - telemetry.istio.io
+          - extensions.istio.io
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - '*'
+    sideEffects: None
 ---
 apiVersion: "security.istio.io/v1beta1"
 kind: "PeerAuthentication"

--- a/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
@@ -6,50 +6,41 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-ingressgateway-service-account
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
     operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway-service-account
+  namespace: istio-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-reader-service-account
-  namespace: istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-service-account
+  namespace: istio-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app: istiod
+    release: istio
   name: istiod
   namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istiod-service-account
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-clusterrole-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-clusterrole-istio-system
 rules:
   - apiGroups:
       - config.istio.io
@@ -79,12 +70,21 @@ rules:
       - watch
   - apiGroups:
       - networking.istio.io
+    resources:
+      - workloadentries
     verbs:
       - get
       - watch
       - list
+  - apiGroups:
+      - networking.x-k8s.io
+      - gateway.networking.k8s.io
     resources:
-      - workloadentries
+      - gateways
+    verbs:
+      - get
+      - watch
+      - list
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -143,105 +143,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-istio-system
-  labels:
-    app: istio-reader
-    release: istio
-rules:
-  - apiGroups:
-      - config.istio.io
-      - security.istio.io
-      - networking.istio.io
-      - authentication.istio.io
-      - rbac.istio.io
-    resources:
-      - '*'
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - endpoints
-      - pods
-      - services
-      - nodes
-      - replicationcontrollers
-      - namespaces
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-    resources:
-      - workloadentries
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - replicasets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceexports
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceimports
-    verbs:
-      - get
-      - watch
-      - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istiod-clusterrole-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-clusterrole-istio-system
 rules:
   - apiGroups:
       - admissionregistration.k8s.io
@@ -270,26 +175,16 @@ rules:
       - rbac.istio.io
       - telemetry.istio.io
       - extensions.istio.io
-    verbs:
-      - get
-      - watch
-      - list
     resources:
       - '*'
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
       - list
-      - update
-      - patch
-      - create
-      - delete
+  - apiGroups:
+      - networking.istio.io
     resources:
       - workloadentries
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
@@ -298,8 +193,18 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - networking.istio.io
     resources:
       - workloadentries/status
+    verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -421,25 +326,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-gateway-controller-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-gateway-controller-istio-system
 rules:
   - apiGroups:
       - apps
-    verbs:
-      - get
-      - watch
-      - list
-      - update
-      - patch
-      - create
-      - delete
     resources:
       - deployments
-  - apiGroups:
-      - ""
     verbs:
       - get
       - watch
@@ -448,10 +343,10 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - ""
     resources:
       - services
-  - apiGroups:
-      - ""
     verbs:
       - get
       - watch
@@ -460,51 +355,10 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - ""
     resources:
       - serviceaccounts
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-rules:
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - mutatingwebhookconfigurations
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-      - patch
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - validatingwebhookconfigurations
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - config.istio.io
-      - security.istio.io
-      - networking.istio.io
-      - authentication.istio.io
-      - rbac.istio.io
-      - telemetry.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-    resources:
-      - '*'
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
@@ -513,164 +367,14 @@ rules:
       - patch
       - create
       - delete
-    resources:
-      - workloadentries
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-      - update
-      - patch
-      - create
-      - delete
-    resources:
-      - workloadentries/status
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-      - services
-      - namespaces
-      - endpoints
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-      - ingressclasses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses/status
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - certificates.k8s.io
-    resources:
-      - certificatesigningrequests
-      - certificatesigningrequests/approval
-      - certificatesigningrequests/status
-    verbs:
-      - update
-      - create
-      - get
-      - delete
-      - watch
-  - apiGroups:
-      - certificates.k8s.io
-    resources:
-      - signers
-    resourceNames:
-      - kubernetes.io/legacy-unknown
-    verbs:
-      - approve
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
-  - apiGroups:
-      - networking.x-k8s.io
-      - gateway.networking.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - networking.x-k8s.io
-      - gateway.networking.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - update
-  - apiGroups:
-      - gateway.networking.k8s.io
-    resources:
-      - gatewayclasses
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceexports
-    verbs:
-      - get
-      - watch
-      - list
-      - create
-      - delete
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceimports
-    verbs:
-      - get
-      - watch
-      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-clusterrole-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-clusterrole-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -683,26 +387,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-istio-system
-  labels:
-    app: istio-reader
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istio-reader-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istio-reader-service-account
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istiod-clusterrole-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-clusterrole-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -715,10 +403,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-gateway-controller-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-gateway-controller-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -726,34 +414,18 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istiod-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istiod-service-account
     namespace: istio-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
-  labels:
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
 rules:
   - apiGroups:
       - ""
@@ -767,18 +439,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod
+  namespace: istio-system
 rules:
   - apiGroups:
       - networking.istio.io
-    verbs:
-      - create
     resources:
       - gateways
+    verbs:
+      - create
   - apiGroups:
       - ""
     resources:
@@ -807,42 +479,15 @@ rules:
       - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: istiod-istio-system
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
-rules:
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - create
-    resources:
-      - gateways
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - get
-      - watch
-      - list
-      - update
-      - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
-  labels:
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -854,11 +499,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod
+  namespace: istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -866,23 +511,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: istiod-istio-system
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: istiod-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istiod-service-account
     namespace: istio-system
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -4190,7 +3818,7 @@ spec:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -4226,6 +3854,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -4302,7 +3931,7 @@ spec:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -4338,6 +3967,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -4373,10 +4003,10 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: istiooperators.install.istio.io
   labels:
     release: istio
     knative.dev/crd-install: "true"
+  name: istiooperators.install.istio.io
 spec:
   conversion:
     strategy: None
@@ -4385,10 +4015,10 @@ spec:
     kind: IstioOperator
     listKind: IstioOperatorList
     plural: istiooperators
-    singular: istiooperator
     shortNames:
       - iop
       - io
+    singular: istiooperator
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
@@ -4404,8 +4034,6 @@ spec:
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-      subresources:
-        status: {}
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -4413,6 +4041,8 @@ spec:
           x-kubernetes-preserve-unknown-fields: true
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5108,7 +4738,7 @@ spec:
                       tls:
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -5144,6 +4774,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -5277,7 +4908,7 @@ spec:
                       tls:
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -5313,6 +4944,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -6133,6 +5765,32 @@ spec:
                             format: double
                             type: number
                         type: object
+                      mirrors:
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            percentage:
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        type: array
                       name:
                         description: The name assigned to the route for debugging purposes.
                         type: string
@@ -6194,6 +5852,16 @@ spec:
                             type: string
                           uri:
                             type: string
+                          uriRegexRewrite:
+                            description: rewrite the path portion of the URI with the specified regex.
+                            properties:
+                              match:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                              rewrite:
+                                description: The string that should replace into matching portions of original URI.
+                                type: string
+                            type: object
                         type: object
                       route:
                         description: A HTTP rule can either return a direct_response, redirect or forward (default) traffic.
@@ -6860,6 +6528,32 @@ spec:
                             format: double
                             type: number
                         type: object
+                      mirrors:
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            percentage:
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        type: array
                       name:
                         description: The name assigned to the route for debugging purposes.
                         type: string
@@ -6921,6 +6615,16 @@ spec:
                             type: string
                           uri:
                             type: string
+                          uriRegexRewrite:
+                            description: rewrite the path portion of the URI with the specified regex.
+                            properties:
+                              match:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                              rewrite:
+                                description: The string that should replace into matching portions of original URI.
+                                type: string
+                            type: object
                         type: object
                       route:
                         description: A HTTP rule can either return a direct_response, redirect or forward (default) traffic.
@@ -7150,6 +6854,12 @@ spec:
             spec:
               description: 'Extend the functionality provided by the Istio proxy through WebAssembly filters. See more details at: https://istio.io/docs/reference/config/proxy_extensions/wasm-plugin.html'
               properties:
+                failStrategy:
+                  description: Specifies the failure behavior for the plugin due to fatal errors.
+                  enum:
+                    - FAIL_CLOSE
+                    - FAIL_OPEN
+                  type: string
                 imagePullPolicy:
                   enum:
                     - UNSPECIFIED_POLICY
@@ -7668,17 +7378,7 @@ spec:
         status: {}
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: istio
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
-    release: istio
 data:
-  meshNetworks: 'networks: {}'
   mesh: |-
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
@@ -7693,130 +7393,19 @@ data:
     enablePrometheusMerge: true
     rootNamespace: istio-system
     trustDomain: cluster.local
----
-apiVersion: v1
+  meshNetworks: 'networks: {}'
 kind: ConfigMap
 metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
   labels:
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Pilot
     release: istio
+  name: istio
+  namespace: istio-system
+---
+apiVersion: v1
 data:
-  values: |-
-    {
-      "global": {
-        "autoscalingv2API": true,
-        "caAddress": "",
-        "caName": "",
-        "certSigners": [],
-        "configCluster": false,
-        "configValidation": true,
-        "defaultNodeSelector": {},
-        "defaultPodDisruptionBudget": {
-          "enabled": true
-        },
-        "defaultResources": {
-          "requests": {
-            "cpu": "10m"
-          }
-        },
-        "enabled": true,
-        "externalIstiod": false,
-        "hub": "docker.io/istio",
-        "imagePullPolicy": "",
-        "imagePullSecrets": [],
-        "istioNamespace": "istio-system",
-        "istiod": {
-          "enableAnalysis": false
-        },
-        "jwtPolicy": "third-party-jwt",
-        "logAsJson": false,
-        "logging": {
-          "level": "default:info"
-        },
-        "meshID": "",
-        "meshNetworks": {},
-        "mountMtlsCerts": false,
-        "multiCluster": {
-          "clusterName": "",
-          "enabled": false
-        },
-        "namespace": "istio-system",
-        "network": "",
-        "omitSidecarInjectorConfigMap": false,
-        "oneNamespace": false,
-        "operatorManageWebhooks": false,
-        "pilotCertProvider": "istiod",
-        "priorityClassName": "",
-        "proxy": {
-          "autoInject": "enabled",
-          "clusterDomain": "cluster.local",
-          "componentLogLevel": "misc:error",
-          "enableCoreDump": false,
-          "excludeIPRanges": "",
-          "excludeInboundPorts": "",
-          "excludeOutboundPorts": "",
-          "image": "proxyv2",
-          "includeIPRanges": "*",
-          "includeInboundPorts": "*",
-          "includeOutboundPorts": "",
-          "logLevel": "warning",
-          "privileged": false,
-          "readinessFailureThreshold": 30,
-          "readinessInitialDelaySeconds": 1,
-          "readinessPeriodSeconds": 2,
-          "resources": {
-            "limits": {
-              "cpu": "2000m",
-              "memory": "1024Mi"
-            },
-            "requests": {
-              "cpu": "100m",
-              "memory": "128Mi"
-            }
-          },
-          "statusPort": 15020,
-          "tracer": "zipkin"
-        },
-        "proxy_init": {
-          "image": "proxyv2"
-        },
-        "remotePilotAddress": "",
-        "sds": {
-          "token": {
-            "aud": "istio-ca"
-          }
-        },
-        "sts": {
-          "servicePort": 0
-        },
-        "tag": "1.18.0",
-        "tracer": {
-          "datadog": {},
-          "lightstep": {},
-          "stackdriver": {},
-          "zipkin": {}
-        },
-        "useMCP": false,
-        "variant": ""
-      },
-      "istio_cni": {
-        "enabled": false
-      },
-      "revision": "",
-      "sidecarInjectorWebhook": {
-        "alwaysInjectSelector": [],
-        "defaultTemplates": [],
-        "enableNamespacesByDefault": false,
-        "injectedAnnotations": {},
-        "neverInjectSelector": [],
-        "rewriteAppHTTPProbe": true,
-        "templates": {}
-      }
-    }
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
     defaultTemplates: [sidecar]
@@ -7855,6 +7444,7 @@ data:
             {{- end }}
           {{- end }}
         {{- end }}
+        {{ $nativeSidecar := (eq (env "ENABLE_NATIVE_SIDECARS" "false") "true") }}
         {{- $containers := list }}
         {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
         metadata:
@@ -7877,7 +7467,7 @@ data:
             {{- end }}
         {{- if .Values.istio_cni.enabled }}
             {{- if not .Values.istio_cni.chained }}
-            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
+            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
             {{- end }}
             sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
             {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
@@ -8015,13 +7605,16 @@ data:
               runAsNonRoot: false
               runAsUser: 0
           {{ end }}
+          {{ if not $nativeSidecar }}
           containers:
+          {{ end }}
           - name: istio-proxy
           {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
             image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
           {{- else }}
             image: "{{ .ProxyImage }}"
           {{- end }}
+            {{ if $nativeSidecar }}restartPolicy: Always{{end}}
             ports:
             - containerPort: 15090
               protocol: TCP
@@ -8108,6 +7701,14 @@ data:
                 ]
             - name: ISTIO_META_APP_CONTAINERS
               value: "{{ $containers | join "," }}"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
             - name: ISTIO_META_NODE_NAME
@@ -8155,7 +7756,11 @@ data:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
+          {{ if $nativeSidecar }}
+            startupProbe:
+          {{ else }}
             readinessProbe:
+          {{ end }}
               httpGet:
                 path: /healthz/ready
                 port: 15021
@@ -8338,10 +7943,6 @@ data:
             - name: {{ . }}
             {{- end }}
           {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
-          {{- end }}
       gateway: |
         {{- $containers := list }}
         {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
@@ -8437,6 +8038,14 @@ data:
                   {{- end}}
                 {{- end}}
                 ]
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: ISTIO_META_APP_CONTAINERS
               value: "{{ $containers | join "," }}"
             - name: ISTIO_META_CLUSTER_ID
@@ -8575,10 +8184,6 @@ data:
             {{- range .Values.global.imagePullSecrets }}
             - name: {{ . }}
             {{- end }}
-          {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
           {{- end }}
       grpc-simple: |
         metadata:
@@ -8963,10 +8568,6 @@ data:
             - name: {{ . }}
             {{- end }}
           {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
-          {{- end }}
       waypoint: |
         apiVersion: v1
         kind: ServiceAccount
@@ -9020,7 +8621,17 @@ data:
               terminationGracePeriodSeconds: 2
               serviceAccountName: {{.ServiceAccount | quote}}
               containers:
-              - args:
+              - name: istio-proxy
+                ports:
+                - containerPort: 15021
+                  name: status-port
+                  protocol: TCP
+                - containerPort: 15090
+                  protocol: TCP
+                  name: http-envoy-prom
+                image: {{.ProxyImage}}
+                {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+                args:
                 - proxy
                 - waypoint
                 - --domain
@@ -9082,6 +8693,14 @@ data:
                 - name: PROXY_CONFIG
                   value: |
                          {{ protoToJSON .ProxyConfig }}
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                - name: GOMAXPROCS
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
                 - name: ISTIO_META_CLUSTER_ID
                   value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
                 - name: ISTIO_META_INTERCEPTION_MODE
@@ -9097,9 +8716,6 @@ data:
                 - name: ISTIO_META_MESH_ID
                   value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
                 {{- end }}
-                image: {{.ProxyImage}}
-                {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-                name: istio-proxy
                 resources:
                   limits:
                     cpu: "2"
@@ -9199,12 +8815,18 @@ data:
             uid: "{{.UID}}"
         spec:
           ports:
-          - name: https-hbone
-            port: 15008
+          {{- range $key, $val := .Ports }}
+          - name: {{ $val.Name | quote }}
+            port: {{ $val.Port }}
             protocol: TCP
-            appProtocol: https
+            appProtocol: {{ $val.AppProtocol }}
+          {{- end }}
           selector:
             istio.io/gateway-name: "{{.Name}}"
+          {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
+          loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
+          {{- end }}
+          type: {{ .ServiceType | quote }}
         ---
       kube-gateway: |
         apiVersion: v1
@@ -9263,6 +8885,10 @@ data:
               containers:
               - name: istio-proxy
                 image: "{{ .ProxyImage }}"
+                {{- if .Values.global.proxy.resources }}
+                resources:
+                  {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+                {{- end }}
                 {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
                 securityContext:
                 {{- if .KubeVersion122 }}
@@ -9358,6 +8984,14 @@ data:
                   value: "[]"
                 - name: ISTIO_META_APP_CONTAINERS
                   value: ""
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                - name: GOMAXPROCS
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
                 - name: ISTIO_META_CLUSTER_ID
                   value: "{{ valueOrDefault .Values.global.multiCluster.clusterName .ClusterID }}"
                 - name: ISTIO_META_NODE_NAME
@@ -9366,9 +9000,9 @@ data:
                       fieldPath: spec.nodeName
                 - name: ISTIO_META_INTERCEPTION_MODE
                   value: "{{ .ProxyConfig.InterceptionMode.String }}"
-                {{- if .Values.global.network }}
+                {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
                 - name: ISTIO_META_NETWORK
-                  value: "{{ .Values.global.network }}"
+                  value: {{.|quote}}
                 {{- end }}
                 - name: ISTIO_META_WORKLOAD_NAME
                   value: {{.DeploymentName|quote}}
@@ -9514,11 +9148,134 @@ data:
           {{- end }}
           selector:
             istio.io/gateway-name: {{.Name}}
-          {{- if .Spec.Addresses }}
+          {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
           loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
           {{- end }}
-          type: {{ index .Annotations "networking.istio.io/service-type" | default "LoadBalancer" | quote }}
+          type: {{ .ServiceType | quote }}
         ---
+  values: |-
+    {
+      "global": {
+        "autoscalingv2API": true,
+        "caAddress": "",
+        "caName": "",
+        "certSigners": [],
+        "configCluster": false,
+        "configValidation": true,
+        "defaultNodeSelector": {},
+        "defaultPodDisruptionBudget": {
+          "enabled": true
+        },
+        "defaultResources": {
+          "requests": {
+            "cpu": "10m"
+          }
+        },
+        "enabled": true,
+        "externalIstiod": false,
+        "hub": "docker.io/istio",
+        "imagePullPolicy": "",
+        "imagePullSecrets": [],
+        "istioNamespace": "istio-system",
+        "istiod": {
+          "enableAnalysis": false
+        },
+        "jwtPolicy": "third-party-jwt",
+        "logAsJson": false,
+        "logging": {
+          "level": "default:info"
+        },
+        "meshID": "",
+        "meshNetworks": {},
+        "mountMtlsCerts": false,
+        "multiCluster": {
+          "clusterName": "",
+          "enabled": false
+        },
+        "namespace": "istio-system",
+        "network": "",
+        "omitSidecarInjectorConfigMap": false,
+        "oneNamespace": false,
+        "operatorManageWebhooks": false,
+        "pilotCertProvider": "istiod",
+        "priorityClassName": "",
+        "proxy": {
+          "autoInject": "enabled",
+          "clusterDomain": "cluster.local",
+          "componentLogLevel": "misc:error",
+          "enableCoreDump": false,
+          "excludeIPRanges": "",
+          "excludeInboundPorts": "",
+          "excludeOutboundPorts": "",
+          "image": "proxyv2",
+          "includeIPRanges": "*",
+          "includeInboundPorts": "*",
+          "includeOutboundPorts": "",
+          "logLevel": "warning",
+          "privileged": false,
+          "readinessFailureThreshold": 30,
+          "readinessInitialDelaySeconds": 1,
+          "readinessPeriodSeconds": 2,
+          "resources": {
+            "limits": {
+              "cpu": "2000m",
+              "memory": "1024Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          },
+          "statusPort": 15020,
+          "tracer": "zipkin"
+        },
+        "proxy_init": {
+          "image": "proxyv2"
+        },
+        "remotePilotAddress": "",
+        "sds": {
+          "token": {
+            "aud": "istio-ca"
+          }
+        },
+        "sts": {
+          "servicePort": 0
+        },
+        "tag": "1.19.0",
+        "tracer": {
+          "datadog": {},
+          "lightstep": {},
+          "stackdriver": {},
+          "zipkin": {}
+        },
+        "useMCP": false,
+        "variant": ""
+      },
+      "istio_cni": {
+        "chained": true,
+        "enabled": false
+      },
+      "revision": "",
+      "sidecarInjectorWebhook": {
+        "alwaysInjectSelector": [],
+        "defaultTemplates": [],
+        "enableNamespacesByDefault": false,
+        "injectedAnnotations": {},
+        "neverInjectSelector": [],
+        "reinvocationPolicy": "Never",
+        "rewriteAppHTTPProbe": true,
+        "templates": {}
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istio-sidecar-injector
+  namespace: istio-system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -9632,7 +9389,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: docker.io/istio/proxyv2:1.18.0
+          image: docker.io/istio/proxyv2:1.19.0
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -9746,45 +9503,40 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istiod
+  namespace: istio-system
 spec:
+  selector:
+    matchLabels:
+      istio: pilot
   strategy:
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 25%
-  selector:
-    matchLabels:
-      istio: pilot
   template:
     metadata:
-      labels:
-        app: istiod
-        istio.io/rev: default
-        install.operator.istio.io/owning-resource: unknown
-        sidecar.istio.io/inject: "false"
-        operator.istio.io/component: Pilot
-        istio: pilot
       annotations:
+        ambient.istio.io/redirection: disabled
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
-        ambient.istio.io/redirection: disabled
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: istiod
+        install.operator.istio.io/owning-resource: unknown
+        istio: pilot
+        istio.io/rev: default
+        operator.istio.io/component: Pilot
         sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: istiod
-      securityContext:
-        fsGroup: 1337
       containers:
-        - name: discovery
-          image: docker.io/istio/pilot:1.18.0
-          args:
+        - args:
             - discovery
             - --monitoringAddr=:15014
             - --log_output_level=default:info
@@ -9792,20 +9544,6 @@ spec:
             - cluster.local
             - --keepaliveMaxServerConnectionAge
             - 30m
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-            - containerPort: 15010
-              protocol: TCP
-            - containerPort: 15017
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            initialDelaySeconds: 1
-            periodSeconds: 3
-            timeoutSeconds: 5
           env:
             - name: REVISION
               value: default
@@ -9832,10 +9570,6 @@ spec:
               value: /var/run/secrets/remote/config
             - name: PILOT_TRACE_SAMPLING
               value: "1"
-            - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
-              value: "true"
-            - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
-              value: "true"
             - name: ISTIOD_ADDR
               value: istiod.istio-system.svc:15012
             - name: PILOT_ENABLE_ANALYSIS
@@ -9846,37 +9580,62 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: PLATFORM
+              value: ""
+          image: docker.io/istio/pilot:1.19.0
+          name: discovery
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 15010
+              protocol: TCP
+            - containerPort: 15017
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            timeoutSeconds: 5
           resources:
             requests:
               cpu: 500m
               memory: 2048Mi
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1337
-            runAsGroup: 1337
-            runAsNonRoot: true
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
           volumeMounts:
-            - name: istio-token
-              mountPath: /var/run/secrets/tokens
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
               readOnly: true
-            - name: local-certs
-              mountPath: /var/run/secrets/istio-dns
-            - name: cacerts
-              mountPath: /etc/cacerts
+            - mountPath: /var/run/secrets/istio-dns
+              name: local-certs
+            - mountPath: /etc/cacerts
+              name: cacerts
               readOnly: true
-            - name: istio-kubeconfig
-              mountPath: /var/run/secrets/remote
+            - mountPath: /var/run/secrets/remote
+              name: istio-kubeconfig
               readOnly: true
-            - name: istio-csr-dns-cert
-              mountPath: /var/run/secrets/istiod/tls
+            - mountPath: /var/run/secrets/istiod/tls
+              name: istio-csr-dns-cert
               readOnly: true
-            - name: istio-csr-ca-configmap
-              mountPath: /var/run/secrets/istiod/ca
+            - mountPath: /var/run/secrets/istiod/ca
+              name: istio-csr-ca-configmap
               readOnly: true
+      securityContext:
+        fsGroup: 1337
+      serviceAccountName: istiod
       volumes:
         - emptyDir:
             medium: Memory
@@ -9890,40 +9649,36 @@ spec:
                   path: istio-token
         - name: cacerts
           secret:
-            secretName: cacerts
             optional: true
+            secretName: cacerts
         - name: istio-kubeconfig
           secret:
-            secretName: istio-kubeconfig
             optional: true
+            secretName: istio-kubeconfig
         - name: istio-csr-dns-cert
           secret:
+            optional: true
             secretName: istiod-tls
-            optional: true
-        - name: istio-csr-ca-configmap
-          configMap:
-            name: istio-ca-root-cert
+        - configMap:
             defaultMode: 420
+            name: istio-ca-root-cert
             optional: true
+          name: istio-csr-ca-configmap
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   annotations: null
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
-spec:
-  type: LoadBalancer
-  selector:
-    app: istio-ingressgateway
     istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
   ports:
     - name: status-port
       port: 15021
@@ -9937,33 +9692,37 @@ spec:
       port: 443
       protocol: TCP
       targetPort: 8443
+  selector:
+    app: istio-ingressgateway
+    istio: ingressgateway
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: istiod
+    install.operator.istio.io/owning-resource: unknown
+    istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
   name: istiod
   namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
-    app: istiod
-    istio: pilot
-    release: istio
 spec:
   ports:
-    - port: 15010
-      name: grpc-xds
+    - name: grpc-xds
+      port: 15010
       protocol: TCP
-    - port: 15012
-      name: https-dns
+    - name: https-dns
+      port: 15012
       protocol: TCP
-    - port: 443
-      name: https-webhook
+    - name: https-webhook
+      port: 443
+      protocol: TCP
       targetPort: 15017
-      protocol: TCP
-    - port: 15014
-      name: http-monitoring
+    - name: http-monitoring
+      port: 15014
       protocol: TCP
   selector:
     app: istiod
@@ -9972,41 +9731,41 @@ spec:
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Pilot
+    release: istio
+  name: istiod
+  namespace: istio-system
 spec:
   maxReplicas: 10
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 60
+          type: Utilization
+      type: Resource
   minReplicas: 3
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: istiod
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 60
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
     operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
@@ -10017,15 +9776,15 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: pilot
+    istio.io/rev: default
     operator.istio.io/component: Pilot
     release: istio
-    istio: pilot
+  name: istiod
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
@@ -10036,35 +9795,25 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: istio-sidecar-injector
   labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     app: sidecar-injector
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istio-sidecar-injector
 webhooks:
-  - name: rev.namespace.sidecar-injector.istio.io
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.namespace.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio.io/rev
@@ -10079,27 +9828,28 @@ webhooks:
           operator: NotIn
           values:
             - "false"
-  - name: rev.object.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.object.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio.io/rev
@@ -10116,27 +9866,28 @@ webhooks:
           operator: In
           values:
             - default
-  - name: namespace.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: namespace.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio-injection
@@ -10149,27 +9900,28 @@ webhooks:
           operator: NotIn
           values:
             - "false"
-  - name: object.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: object.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio-injection
@@ -10184,44 +9936,55 @@ webhooks:
             - "true"
         - key: istio.io/rev
           operator: DoesNotExist
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istio-validator-istio-system
   labels:
     app: istiod
-    release: istio
     istio: istiod
     istio.io/rev: default
+    release: istio
+  name: istio-validator-istio-system
 webhooks:
-  - name: rev.validation.istio.io
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /validate
-    rules:
-      - operations:
-          - CREATE
-          - UPDATE
-        apiGroups:
-          - security.istio.io
-          - networking.istio.io
-          - telemetry.istio.io
-          - extensions.istio.io
-        apiVersions:
-          - '*'
-        resources:
-          - '*'
     failurePolicy: Ignore
-    sideEffects: None
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.validation.istio.io
     objectSelector:
       matchExpressions:
         - key: istio.io/rev
           operator: In
           values:
             - default
+    rules:
+      - apiGroups:
+          - security.istio.io
+          - networking.istio.io
+          - telemetry.istio.io
+          - extensions.istio.io
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - '*'
+    sideEffects: None

--- a/third_party/istio-latest/istio-kind-ambient/istio.yaml
+++ b/third_party/istio-latest/istio-kind-ambient/istio.yaml
@@ -6,73 +6,64 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-cni
-  namespace: istio-system
   labels:
     app: istio-cni
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Cni
+    release: istio
+  name: istio-cni
+  namespace: istio-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-ingressgateway-service-account
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
     operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway-service-account
+  namespace: istio-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-reader-service-account
-  namespace: istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-service-account
+  namespace: istio-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app: istiod
+    release: istio
   name: istiod
   namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istiod-service-account
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
+  annotations: {}
+  labels: {}
   name: ztunnel
   namespace: istio-system
-  labels: {}
-  annotations: {}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-cni
   labels:
     app: istio-cni
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Cni
+    release: istio
+  name: istio-cni
 rules:
   - apiGroups:
       - ""
@@ -88,13 +79,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-cni-repair-role
   labels:
     app: istio-cni
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Cni
+    release: istio
+  name: istio-cni-repair-role
 rules:
   - apiGroups:
       - ""
@@ -123,10 +114,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-clusterrole-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-clusterrole-istio-system
 rules:
   - apiGroups:
       - config.istio.io
@@ -156,12 +147,21 @@ rules:
       - watch
   - apiGroups:
       - networking.istio.io
+    resources:
+      - workloadentries
     verbs:
       - get
       - watch
       - list
+  - apiGroups:
+      - networking.x-k8s.io
+      - gateway.networking.k8s.io
     resources:
-      - workloadentries
+      - gateways
+    verbs:
+      - get
+      - watch
+      - list
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -220,105 +220,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-istio-system
-  labels:
-    app: istio-reader
-    release: istio
-rules:
-  - apiGroups:
-      - config.istio.io
-      - security.istio.io
-      - networking.istio.io
-      - authentication.istio.io
-      - rbac.istio.io
-    resources:
-      - '*'
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - endpoints
-      - pods
-      - services
-      - nodes
-      - replicationcontrollers
-      - namespaces
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-    resources:
-      - workloadentries
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - replicasets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceexports
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceimports
-    verbs:
-      - get
-      - watch
-      - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istiod-clusterrole-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-clusterrole-istio-system
 rules:
   - apiGroups:
       - admissionregistration.k8s.io
@@ -347,26 +252,16 @@ rules:
       - rbac.istio.io
       - telemetry.istio.io
       - extensions.istio.io
-    verbs:
-      - get
-      - watch
-      - list
     resources:
       - '*'
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
       - list
-      - update
-      - patch
-      - create
-      - delete
+  - apiGroups:
+      - networking.istio.io
     resources:
       - workloadentries
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
@@ -375,8 +270,18 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - networking.istio.io
     resources:
       - workloadentries/status
+    verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -498,25 +403,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-gateway-controller-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-gateway-controller-istio-system
 rules:
   - apiGroups:
       - apps
-    verbs:
-      - get
-      - watch
-      - list
-      - update
-      - patch
-      - create
-      - delete
     resources:
       - deployments
-  - apiGroups:
-      - ""
     verbs:
       - get
       - watch
@@ -525,10 +420,10 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - ""
     resources:
       - services
-  - apiGroups:
-      - ""
     verbs:
       - get
       - watch
@@ -537,51 +432,10 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - ""
     resources:
       - serviceaccounts
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-rules:
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - mutatingwebhookconfigurations
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-      - patch
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - validatingwebhookconfigurations
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - config.istio.io
-      - security.istio.io
-      - networking.istio.io
-      - authentication.istio.io
-      - rbac.istio.io
-      - telemetry.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-    resources:
-      - '*'
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
@@ -590,167 +444,17 @@ rules:
       - patch
       - create
       - delete
-    resources:
-      - workloadentries
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-      - update
-      - patch
-      - create
-      - delete
-    resources:
-      - workloadentries/status
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-      - services
-      - namespaces
-      - endpoints
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-      - ingressclasses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses/status
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - certificates.k8s.io
-    resources:
-      - certificatesigningrequests
-      - certificatesigningrequests/approval
-      - certificatesigningrequests/status
-    verbs:
-      - update
-      - create
-      - get
-      - delete
-      - watch
-  - apiGroups:
-      - certificates.k8s.io
-    resources:
-      - signers
-    resourceNames:
-      - kubernetes.io/legacy-unknown
-    verbs:
-      - approve
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
-  - apiGroups:
-      - networking.x-k8s.io
-      - gateway.networking.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - networking.x-k8s.io
-      - gateway.networking.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - update
-  - apiGroups:
-      - gateway.networking.k8s.io
-    resources:
-      - gatewayclasses
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceexports
-    verbs:
-      - get
-      - watch
-      - list
-      - create
-      - delete
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceimports
-    verbs:
-      - get
-      - watch
-      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-cni
   labels:
     app: istio-cni
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Cni
+    release: istio
+  name: istio-cni
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -763,28 +467,28 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-cni-repair-rolebinding
   labels:
-    k8s-app: istio-cni-repair
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    k8s-app: istio-cni-repair
     operator.istio.io/component: Cni
-subjects:
-  - kind: ServiceAccount
-    name: istio-cni
-    namespace: istio-system
+  name: istio-cni-repair-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: istio-cni-repair-role
+subjects:
+  - kind: ServiceAccount
+    name: istio-cni
+    namespace: istio-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-clusterrole-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-clusterrole-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -797,26 +501,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-istio-system
-  labels:
-    app: istio-reader
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istio-reader-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istio-reader-service-account
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istiod-clusterrole-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-clusterrole-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -829,10 +517,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-gateway-controller-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-gateway-controller-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -840,34 +528,18 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istiod-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istiod-service-account
     namespace: istio-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
-  labels:
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
 rules:
   - apiGroups:
       - ""
@@ -881,18 +553,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod
+  namespace: istio-system
 rules:
   - apiGroups:
       - networking.istio.io
-    verbs:
-      - create
     resources:
       - gateways
+    verbs:
+      - create
   - apiGroups:
       - ""
     resources:
@@ -921,42 +593,15 @@ rules:
       - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: istiod-istio-system
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
-rules:
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - create
-    resources:
-      - gateways
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - get
-      - watch
-      - list
-      - update
-      - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
-  labels:
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -968,11 +613,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod
+  namespace: istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -980,23 +625,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: istiod-istio-system
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: istiod-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istiod-service-account
     namespace: istio-system
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -4304,7 +3932,7 @@ spec:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -4340,6 +3968,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -4416,7 +4045,7 @@ spec:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -4452,6 +4081,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -4487,10 +4117,10 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: istiooperators.install.istio.io
   labels:
     release: istio
     knative.dev/crd-install: "true"
+  name: istiooperators.install.istio.io
 spec:
   conversion:
     strategy: None
@@ -4499,10 +4129,10 @@ spec:
     kind: IstioOperator
     listKind: IstioOperatorList
     plural: istiooperators
-    singular: istiooperator
     shortNames:
       - iop
       - io
+    singular: istiooperator
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
@@ -4518,8 +4148,6 @@ spec:
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-      subresources:
-        status: {}
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -4527,6 +4155,8 @@ spec:
           x-kubernetes-preserve-unknown-fields: true
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5222,7 +4852,7 @@ spec:
                       tls:
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -5258,6 +4888,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -5391,7 +5022,7 @@ spec:
                       tls:
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -5427,6 +5058,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -6247,6 +5879,32 @@ spec:
                             format: double
                             type: number
                         type: object
+                      mirrors:
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            percentage:
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        type: array
                       name:
                         description: The name assigned to the route for debugging purposes.
                         type: string
@@ -6308,6 +5966,16 @@ spec:
                             type: string
                           uri:
                             type: string
+                          uriRegexRewrite:
+                            description: rewrite the path portion of the URI with the specified regex.
+                            properties:
+                              match:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                              rewrite:
+                                description: The string that should replace into matching portions of original URI.
+                                type: string
+                            type: object
                         type: object
                       route:
                         description: A HTTP rule can either return a direct_response, redirect or forward (default) traffic.
@@ -6974,6 +6642,32 @@ spec:
                             format: double
                             type: number
                         type: object
+                      mirrors:
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            percentage:
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        type: array
                       name:
                         description: The name assigned to the route for debugging purposes.
                         type: string
@@ -7035,6 +6729,16 @@ spec:
                             type: string
                           uri:
                             type: string
+                          uriRegexRewrite:
+                            description: rewrite the path portion of the URI with the specified regex.
+                            properties:
+                              match:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                              rewrite:
+                                description: The string that should replace into matching portions of original URI.
+                                type: string
+                            type: object
                         type: object
                       route:
                         description: A HTTP rule can either return a direct_response, redirect or forward (default) traffic.
@@ -7264,6 +6968,12 @@ spec:
             spec:
               description: 'Extend the functionality provided by the Istio proxy through WebAssembly filters. See more details at: https://istio.io/docs/reference/config/proxy_extensions/wasm-plugin.html'
               properties:
+                failStrategy:
+                  description: Specifies the failure behavior for the plugin due to fatal errors.
+                  enum:
+                    - FAIL_CLOSE
+                    - FAIL_OPEN
+                  type: string
                 imagePullPolicy:
                   enum:
                     - UNSPECIFIED_POLICY
@@ -7782,17 +7492,7 @@ spec:
         status: {}
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: istio
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
-    release: istio
 data:
-  meshNetworks: 'networks: {}'
   mesh: |-
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
@@ -7810,18 +7510,18 @@ data:
       prometheus: {}
     rootNamespace: istio-system
     trustDomain: cluster.local
----
+  meshNetworks: 'networks: {}'
 kind: ConfigMap
-apiVersion: v1
 metadata:
-  name: istio-cni-config
-  namespace: istio-system
   labels:
-    app: istio-cni
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Cni
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istio
+  namespace: istio-system
+---
+apiVersion: v1
 data:
   cni_network_config: |-
     {
@@ -7837,130 +7537,19 @@ data:
           "exclude_namespaces": [ "kube-system" ]
       }
     }
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
   labels:
-    istio.io/rev: default
+    app: istio-cni
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
+    istio.io/rev: default
+    operator.istio.io/component: Cni
     release: istio
+  name: istio-cni-config
+  namespace: istio-system
+---
+apiVersion: v1
 data:
-  values: |-
-    {
-      "global": {
-        "autoscalingv2API": true,
-        "caAddress": "",
-        "caName": "",
-        "certSigners": [],
-        "configCluster": false,
-        "configValidation": true,
-        "defaultNodeSelector": {},
-        "defaultPodDisruptionBudget": {
-          "enabled": true
-        },
-        "defaultResources": {
-          "requests": {
-            "cpu": "10m"
-          }
-        },
-        "enabled": true,
-        "externalIstiod": false,
-        "hub": "docker.io/istio",
-        "imagePullPolicy": "",
-        "imagePullSecrets": [],
-        "istioNamespace": "istio-system",
-        "istiod": {
-          "enableAnalysis": false
-        },
-        "jwtPolicy": "third-party-jwt",
-        "logAsJson": false,
-        "logging": {
-          "level": "default:info"
-        },
-        "meshID": "",
-        "meshNetworks": {},
-        "mountMtlsCerts": false,
-        "multiCluster": {
-          "clusterName": "",
-          "enabled": false
-        },
-        "namespace": "istio-system",
-        "network": "",
-        "omitSidecarInjectorConfigMap": false,
-        "oneNamespace": false,
-        "operatorManageWebhooks": false,
-        "pilotCertProvider": "istiod",
-        "priorityClassName": "",
-        "proxy": {
-          "autoInject": "enabled",
-          "clusterDomain": "cluster.local",
-          "componentLogLevel": "misc:error",
-          "enableCoreDump": false,
-          "excludeIPRanges": "",
-          "excludeInboundPorts": "",
-          "excludeOutboundPorts": "",
-          "image": "proxyv2",
-          "includeIPRanges": "*",
-          "includeInboundPorts": "*",
-          "includeOutboundPorts": "",
-          "logLevel": "warning",
-          "privileged": false,
-          "readinessFailureThreshold": 30,
-          "readinessInitialDelaySeconds": 1,
-          "readinessPeriodSeconds": 2,
-          "resources": {
-            "limits": {
-              "cpu": "2000m",
-              "memory": "1024Mi"
-            },
-            "requests": {
-              "cpu": "100m",
-              "memory": "128Mi"
-            }
-          },
-          "statusPort": 15020,
-          "tracer": "zipkin"
-        },
-        "proxy_init": {
-          "image": "proxyv2"
-        },
-        "remotePilotAddress": "",
-        "sds": {
-          "token": {
-            "aud": "istio-ca"
-          }
-        },
-        "sts": {
-          "servicePort": 0
-        },
-        "tag": "1.18.0",
-        "tracer": {
-          "datadog": {},
-          "lightstep": {},
-          "stackdriver": {},
-          "zipkin": {}
-        },
-        "useMCP": false,
-        "variant": ""
-      },
-      "istio_cni": {
-        "enabled": true
-      },
-      "revision": "",
-      "sidecarInjectorWebhook": {
-        "alwaysInjectSelector": [],
-        "defaultTemplates": [],
-        "enableNamespacesByDefault": false,
-        "injectedAnnotations": {},
-        "neverInjectSelector": [],
-        "rewriteAppHTTPProbe": true,
-        "templates": {}
-      }
-    }
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
     defaultTemplates: [sidecar]
@@ -7999,6 +7588,7 @@ data:
             {{- end }}
           {{- end }}
         {{- end }}
+        {{ $nativeSidecar := (eq (env "ENABLE_NATIVE_SIDECARS" "false") "true") }}
         {{- $containers := list }}
         {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
         metadata:
@@ -8021,7 +7611,7 @@ data:
             {{- end }}
         {{- if .Values.istio_cni.enabled }}
             {{- if not .Values.istio_cni.chained }}
-            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
+            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
             {{- end }}
             sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
             {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
@@ -8159,13 +7749,16 @@ data:
               runAsNonRoot: false
               runAsUser: 0
           {{ end }}
+          {{ if not $nativeSidecar }}
           containers:
+          {{ end }}
           - name: istio-proxy
           {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
             image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
           {{- else }}
             image: "{{ .ProxyImage }}"
           {{- end }}
+            {{ if $nativeSidecar }}restartPolicy: Always{{end}}
             ports:
             - containerPort: 15090
               protocol: TCP
@@ -8252,6 +7845,14 @@ data:
                 ]
             - name: ISTIO_META_APP_CONTAINERS
               value: "{{ $containers | join "," }}"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
             - name: ISTIO_META_NODE_NAME
@@ -8299,7 +7900,11 @@ data:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
+          {{ if $nativeSidecar }}
+            startupProbe:
+          {{ else }}
             readinessProbe:
+          {{ end }}
               httpGet:
                 path: /healthz/ready
                 port: 15021
@@ -8482,10 +8087,6 @@ data:
             - name: {{ . }}
             {{- end }}
           {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
-          {{- end }}
       gateway: |
         {{- $containers := list }}
         {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
@@ -8581,6 +8182,14 @@ data:
                   {{- end}}
                 {{- end}}
                 ]
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: ISTIO_META_APP_CONTAINERS
               value: "{{ $containers | join "," }}"
             - name: ISTIO_META_CLUSTER_ID
@@ -8719,10 +8328,6 @@ data:
             {{- range .Values.global.imagePullSecrets }}
             - name: {{ . }}
             {{- end }}
-          {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
           {{- end }}
       grpc-simple: |
         metadata:
@@ -9107,10 +8712,6 @@ data:
             - name: {{ . }}
             {{- end }}
           {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
-          {{- end }}
       waypoint: |
         apiVersion: v1
         kind: ServiceAccount
@@ -9164,7 +8765,17 @@ data:
               terminationGracePeriodSeconds: 2
               serviceAccountName: {{.ServiceAccount | quote}}
               containers:
-              - args:
+              - name: istio-proxy
+                ports:
+                - containerPort: 15021
+                  name: status-port
+                  protocol: TCP
+                - containerPort: 15090
+                  protocol: TCP
+                  name: http-envoy-prom
+                image: {{.ProxyImage}}
+                {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+                args:
                 - proxy
                 - waypoint
                 - --domain
@@ -9226,6 +8837,14 @@ data:
                 - name: PROXY_CONFIG
                   value: |
                          {{ protoToJSON .ProxyConfig }}
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                - name: GOMAXPROCS
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
                 - name: ISTIO_META_CLUSTER_ID
                   value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
                 - name: ISTIO_META_INTERCEPTION_MODE
@@ -9241,9 +8860,6 @@ data:
                 - name: ISTIO_META_MESH_ID
                   value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
                 {{- end }}
-                image: {{.ProxyImage}}
-                {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-                name: istio-proxy
                 resources:
                   limits:
                     cpu: "2"
@@ -9343,12 +8959,18 @@ data:
             uid: "{{.UID}}"
         spec:
           ports:
-          - name: https-hbone
-            port: 15008
+          {{- range $key, $val := .Ports }}
+          - name: {{ $val.Name | quote }}
+            port: {{ $val.Port }}
             protocol: TCP
-            appProtocol: https
+            appProtocol: {{ $val.AppProtocol }}
+          {{- end }}
           selector:
             istio.io/gateway-name: "{{.Name}}"
+          {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
+          loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
+          {{- end }}
+          type: {{ .ServiceType | quote }}
         ---
       kube-gateway: |
         apiVersion: v1
@@ -9407,6 +9029,10 @@ data:
               containers:
               - name: istio-proxy
                 image: "{{ .ProxyImage }}"
+                {{- if .Values.global.proxy.resources }}
+                resources:
+                  {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+                {{- end }}
                 {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
                 securityContext:
                 {{- if .KubeVersion122 }}
@@ -9502,6 +9128,14 @@ data:
                   value: "[]"
                 - name: ISTIO_META_APP_CONTAINERS
                   value: ""
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                - name: GOMAXPROCS
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
                 - name: ISTIO_META_CLUSTER_ID
                   value: "{{ valueOrDefault .Values.global.multiCluster.clusterName .ClusterID }}"
                 - name: ISTIO_META_NODE_NAME
@@ -9510,9 +9144,9 @@ data:
                       fieldPath: spec.nodeName
                 - name: ISTIO_META_INTERCEPTION_MODE
                   value: "{{ .ProxyConfig.InterceptionMode.String }}"
-                {{- if .Values.global.network }}
+                {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
                 - name: ISTIO_META_NETWORK
-                  value: "{{ .Values.global.network }}"
+                  value: {{.|quote}}
                 {{- end }}
                 - name: ISTIO_META_WORKLOAD_NAME
                   value: {{.DeploymentName|quote}}
@@ -9658,11 +9292,134 @@ data:
           {{- end }}
           selector:
             istio.io/gateway-name: {{.Name}}
-          {{- if .Spec.Addresses }}
+          {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
           loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
           {{- end }}
-          type: {{ index .Annotations "networking.istio.io/service-type" | default "LoadBalancer" | quote }}
+          type: {{ .ServiceType | quote }}
         ---
+  values: |-
+    {
+      "global": {
+        "autoscalingv2API": true,
+        "caAddress": "",
+        "caName": "",
+        "certSigners": [],
+        "configCluster": false,
+        "configValidation": true,
+        "defaultNodeSelector": {},
+        "defaultPodDisruptionBudget": {
+          "enabled": true
+        },
+        "defaultResources": {
+          "requests": {
+            "cpu": "10m"
+          }
+        },
+        "enabled": true,
+        "externalIstiod": false,
+        "hub": "docker.io/istio",
+        "imagePullPolicy": "",
+        "imagePullSecrets": [],
+        "istioNamespace": "istio-system",
+        "istiod": {
+          "enableAnalysis": false
+        },
+        "jwtPolicy": "third-party-jwt",
+        "logAsJson": false,
+        "logging": {
+          "level": "default:info"
+        },
+        "meshID": "",
+        "meshNetworks": {},
+        "mountMtlsCerts": false,
+        "multiCluster": {
+          "clusterName": "",
+          "enabled": false
+        },
+        "namespace": "istio-system",
+        "network": "",
+        "omitSidecarInjectorConfigMap": false,
+        "oneNamespace": false,
+        "operatorManageWebhooks": false,
+        "pilotCertProvider": "istiod",
+        "priorityClassName": "",
+        "proxy": {
+          "autoInject": "enabled",
+          "clusterDomain": "cluster.local",
+          "componentLogLevel": "misc:error",
+          "enableCoreDump": false,
+          "excludeIPRanges": "",
+          "excludeInboundPorts": "",
+          "excludeOutboundPorts": "",
+          "image": "proxyv2",
+          "includeIPRanges": "*",
+          "includeInboundPorts": "*",
+          "includeOutboundPorts": "",
+          "logLevel": "warning",
+          "privileged": false,
+          "readinessFailureThreshold": 30,
+          "readinessInitialDelaySeconds": 1,
+          "readinessPeriodSeconds": 2,
+          "resources": {
+            "limits": {
+              "cpu": "2000m",
+              "memory": "1024Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          },
+          "statusPort": 15020,
+          "tracer": "zipkin"
+        },
+        "proxy_init": {
+          "image": "proxyv2"
+        },
+        "remotePilotAddress": "",
+        "sds": {
+          "token": {
+            "aud": "istio-ca"
+          }
+        },
+        "sts": {
+          "servicePort": 0
+        },
+        "tag": "1.19.0",
+        "tracer": {
+          "datadog": {},
+          "lightstep": {},
+          "stackdriver": {},
+          "zipkin": {}
+        },
+        "useMCP": false,
+        "variant": ""
+      },
+      "istio_cni": {
+        "chained": true,
+        "enabled": true
+      },
+      "revision": "",
+      "sidecarInjectorWebhook": {
+        "alwaysInjectSelector": [],
+        "defaultTemplates": [],
+        "enableNamespacesByDefault": false,
+        "injectedAnnotations": {},
+        "neverInjectSelector": [],
+        "reinvocationPolicy": "Never",
+        "rewriteAppHTTPProbe": true,
+        "templates": {}
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istio-sidecar-injector
+  namespace: istio-system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -9778,7 +9535,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: docker.io/istio/proxyv2:1.18.0
+          image: docker.io/istio/proxyv2:1.19.0
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -9892,45 +9649,40 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istiod
+  namespace: istio-system
 spec:
+  selector:
+    matchLabels:
+      istio: pilot
   strategy:
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 25%
-  selector:
-    matchLabels:
-      istio: pilot
   template:
     metadata:
-      labels:
-        app: istiod
-        istio.io/rev: default
-        install.operator.istio.io/owning-resource: unknown
-        sidecar.istio.io/inject: "false"
-        operator.istio.io/component: Pilot
-        istio: pilot
       annotations:
+        ambient.istio.io/redirection: disabled
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
-        ambient.istio.io/redirection: disabled
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: istiod
+        install.operator.istio.io/owning-resource: unknown
+        istio: pilot
+        istio.io/rev: default
+        operator.istio.io/component: Pilot
         sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: istiod
-      securityContext:
-        fsGroup: 1337
       containers:
-        - name: discovery
-          image: docker.io/istio/pilot:1.18.0
-          args:
+        - args:
             - discovery
             - --monitoringAddr=:15014
             - --log_output_level=default:info
@@ -9938,20 +9690,6 @@ spec:
             - cluster.local
             - --keepaliveMaxServerConnectionAge
             - 30m
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-            - containerPort: 15010
-              protocol: TCP
-            - containerPort: 15017
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            initialDelaySeconds: 1
-            periodSeconds: 3
-            timeoutSeconds: 5
           env:
             - name: REVISION
               value: default
@@ -9988,10 +9726,6 @@ spec:
               value: "true"
             - name: PILOT_TRACE_SAMPLING
               value: "1"
-            - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
-              value: "true"
-            - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
-              value: "true"
             - name: ISTIOD_ADDR
               value: istiod.istio-system.svc:15012
             - name: PILOT_ENABLE_ANALYSIS
@@ -10002,37 +9736,62 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: PLATFORM
+              value: ""
+          image: docker.io/istio/pilot:1.19.0
+          name: discovery
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 15010
+              protocol: TCP
+            - containerPort: 15017
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            timeoutSeconds: 5
           resources:
             requests:
               cpu: 500m
               memory: 2048Mi
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1337
-            runAsGroup: 1337
-            runAsNonRoot: true
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
           volumeMounts:
-            - name: istio-token
-              mountPath: /var/run/secrets/tokens
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
               readOnly: true
-            - name: local-certs
-              mountPath: /var/run/secrets/istio-dns
-            - name: cacerts
-              mountPath: /etc/cacerts
+            - mountPath: /var/run/secrets/istio-dns
+              name: local-certs
+            - mountPath: /etc/cacerts
+              name: cacerts
               readOnly: true
-            - name: istio-kubeconfig
-              mountPath: /var/run/secrets/remote
+            - mountPath: /var/run/secrets/remote
+              name: istio-kubeconfig
               readOnly: true
-            - name: istio-csr-dns-cert
-              mountPath: /var/run/secrets/istiod/tls
+            - mountPath: /var/run/secrets/istiod/tls
+              name: istio-csr-dns-cert
               readOnly: true
-            - name: istio-csr-ca-configmap
-              mountPath: /var/run/secrets/istiod/ca
+            - mountPath: /var/run/secrets/istiod/ca
+              name: istio-csr-ca-configmap
               readOnly: true
+      securityContext:
+        fsGroup: 1337
+      serviceAccountName: istiod
       volumes:
         - emptyDir:
             medium: Memory
@@ -10046,40 +9805,36 @@ spec:
                   path: istio-token
         - name: cacerts
           secret:
-            secretName: cacerts
             optional: true
+            secretName: cacerts
         - name: istio-kubeconfig
           secret:
-            secretName: istio-kubeconfig
             optional: true
+            secretName: istio-kubeconfig
         - name: istio-csr-dns-cert
           secret:
+            optional: true
             secretName: istiod-tls
-            optional: true
-        - name: istio-csr-ca-configmap
-          configMap:
-            name: istio-ca-root-cert
+        - configMap:
             defaultMode: 420
+            name: istio-ca-root-cert
             optional: true
+          name: istio-csr-ca-configmap
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   annotations: null
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
-spec:
-  type: LoadBalancer
-  selector:
-    app: istio-ingressgateway
     istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
   ports:
     - name: status-port
       port: 15021
@@ -10093,33 +9848,37 @@ spec:
       port: 443
       protocol: TCP
       targetPort: 8443
+  selector:
+    app: istio-ingressgateway
+    istio: ingressgateway
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: istiod
+    install.operator.istio.io/owning-resource: unknown
+    istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
   name: istiod
   namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
-    app: istiod
-    istio: pilot
-    release: istio
 spec:
   ports:
-    - port: 15010
-      name: grpc-xds
+    - name: grpc-xds
+      port: 15010
       protocol: TCP
-    - port: 15012
-      name: https-dns
+    - name: https-dns
+      port: 15012
       protocol: TCP
-    - port: 443
-      name: https-webhook
+    - name: https-webhook
+      port: 443
+      protocol: TCP
       targetPort: 15017
-      protocol: TCP
-    - port: 15014
-      name: http-monitoring
+    - name: http-monitoring
+      port: 15014
       protocol: TCP
   selector:
     app: istiod
@@ -10128,41 +9887,41 @@ spec:
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Pilot
+    release: istio
+  name: istiod
+  namespace: istio-system
 spec:
   maxReplicas: 3
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 60
+          type: Utilization
+      type: Resource
   minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: istiod
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 60
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
     operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
@@ -10173,15 +9932,15 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: pilot
+    istio.io/rev: default
     operator.istio.io/component: Pilot
     release: istio
-    istio: pilot
+  name: istiod
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
@@ -10192,35 +9951,25 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: istio-sidecar-injector
   labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     app: sidecar-injector
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istio-sidecar-injector
 webhooks:
-  - name: rev.namespace.sidecar-injector.istio.io
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.namespace.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio.io/rev
@@ -10235,27 +9984,28 @@ webhooks:
           operator: NotIn
           values:
             - "false"
-  - name: rev.object.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.object.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio.io/rev
@@ -10272,27 +10022,28 @@ webhooks:
           operator: In
           values:
             - default
-  - name: namespace.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: namespace.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio-injection
@@ -10305,27 +10056,28 @@ webhooks:
           operator: NotIn
           values:
             - "false"
-  - name: object.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: object.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio-injection
@@ -10340,114 +10092,97 @@ webhooks:
             - "true"
         - key: istio.io/rev
           operator: DoesNotExist
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istio-validator-istio-system
   labels:
     app: istiod
-    release: istio
     istio: istiod
     istio.io/rev: default
+    release: istio
+  name: istio-validator-istio-system
 webhooks:
-  - name: rev.validation.istio.io
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /validate
-    rules:
-      - operations:
-          - CREATE
-          - UPDATE
-        apiGroups:
-          - security.istio.io
-          - networking.istio.io
-          - telemetry.istio.io
-          - extensions.istio.io
-        apiVersions:
-          - '*'
-        resources:
-          - '*'
     failurePolicy: Ignore
-    sideEffects: None
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.validation.istio.io
     objectSelector:
       matchExpressions:
         - key: istio.io/rev
           operator: In
           values:
             - default
+    rules:
+      - apiGroups:
+          - security.istio.io
+          - networking.istio.io
+          - telemetry.istio.io
+          - extensions.istio.io
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - '*'
+    sideEffects: None
 ---
-kind: DaemonSet
 apiVersion: apps/v1
+kind: DaemonSet
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    k8s-app: istio-cni-node
+    operator.istio.io/component: Cni
+    release: istio
   name: istio-cni-node
   namespace: istio-system
-  labels:
-    k8s-app: istio-cni-node
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Cni
 spec:
   selector:
     matchLabels:
       k8s-app: istio-cni-node
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
   template:
     metadata:
+      annotations:
+        ambient.istio.io/redirection: disabled
+        prometheus.io/path: /metrics
+        prometheus.io/port: "15014"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "false"
       labels:
         k8s-app: istio-cni-node
         sidecar.istio.io/inject: "false"
-      annotations:
-        sidecar.istio.io/inject: "false"
-        ambient.istio.io/redirection: disabled
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "15014"
-        prometheus.io/path: /metrics
     spec:
-      hostNetwork: true
-      nodeSelector:
-        kubernetes.io/os: linux
-      tolerations:
-        - effect: NoSchedule
-          operator: Exists
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - effect: NoExecute
-          operator: Exists
-      priorityClassName: system-node-critical
-      serviceAccountName: istio-cni
-      terminationGracePeriodSeconds: 5
       containers:
-        - name: install-cni
-          image: docker.io/istio/install-cni:1.18.0
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: 8000
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-            runAsNonRoot: false
-            privileged: true
+        - args:
+            - --log_output_level=default:info
           command:
             - install-cni
-          args:
-            - --log_output_level=default:info
           env:
             - name: CNI_NETWORK_CONFIG
               valueFrom:
                 configMapKeyRef:
-                  name: istio-cni-config
                   key: cni_network_config
+                  name: istio-cni-config
             - name: CNI_NET_DIR
               value: /etc/cni/net.d
             - name: CHAINED_CNI_PLUGIN
@@ -10481,6 +10216,29 @@ spec:
               value: info
             - name: AMBIENT_ENABLED
               value: "true"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          image: docker.io/istio/install-cni:1.19.0
+          name: install-cni
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          securityContext:
+            privileged: true
+            runAsGroup: 0
+            runAsNonRoot: false
+            runAsUser: 0
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
@@ -10489,59 +10247,16 @@ spec:
             - mountPath: /var/run/istio-cni
               name: cni-log-dir
             - mountPath: /etc/ambient-config
-              name: cni-ambientconfig
+              name: cni-ambient-config-dir
             - mountPath: /var/run/netns
               mountPropagation: HostToContainer
               name: cni-netns-dir
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
-      volumes:
-        - name: cni-bin-dir
-          hostPath:
-            path: /opt/cni/bin
-        - name: cni-ambientconfig
-          hostPath:
-            path: /etc/ambient-config
-        - name: cni-net-dir
-          hostPath:
-            path: /etc/cni/net.d
-        - name: cni-log-dir
-          hostPath:
-            path: /var/run/istio-cni
-        - name: cni-netns-dir
-          hostPath:
-            path: /var/run/netns
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: ztunnel
-  namespace: istio-system
-  labels: {}
-  annotations: {}
-spec:
-  updateStrategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-  selector:
-    matchLabels:
-      app: ztunnel
-  template:
-    metadata:
-      labels:
-        sidecar.istio.io/inject: "false"
-        app: ztunnel
-      annotations:
-        cni.projectcalico.org/allowedSourcePrefixes: '["0.0.0.0/0"]'
-        ambient.istio.io/redirection: disabled
-        sidecar.istio.io/inject: "false"
-        prometheus.io/port: "15020"
-        prometheus.io/scrape: "true"
-    spec:
-      serviceAccountName: ztunnel
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-node-critical
+      serviceAccountName: istio-cni
+      terminationGracePeriodSeconds: 5
       tolerations:
         - effect: NoSchedule
           operator: Exists
@@ -10549,30 +10264,52 @@ spec:
           operator: Exists
         - effect: NoExecute
           operator: Exists
+      volumes:
+        - hostPath:
+            path: /opt/cni/bin
+          name: cni-bin-dir
+        - hostPath:
+            path: /etc/ambient-config
+          name: cni-ambient-config-dir
+        - hostPath:
+            path: /etc/cni/net.d
+          name: cni-net-dir
+        - hostPath:
+            path: /var/run/istio-cni
+          name: cni-log-dir
+        - hostPath:
+            path: /var/run/netns
+          name: cni-netns-dir
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations: {}
+  labels: {}
+  name: ztunnel
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      app: ztunnel
+  template:
+    metadata:
+      annotations:
+        ambient.istio.io/redirection: disabled
+        cni.projectcalico.org/allowedSourcePrefixes: '["0.0.0.0/0"]'
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: ztunnel
+        sidecar.istio.io/inject: "false"
+    spec:
       containers:
-        - name: istio-proxy
-          image: docker.io/istio/ztunnel:1.18.0
-          resources:
-            requests:
-              cpu: 500m
-              memory: 2048Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            privileged: false
-            capabilities:
-              drop:
-                - ALL
-              add:
-                - NET_ADMIN
-            readOnlyRootFilesystem: true
-            runAsGroup: 1337
-            runAsNonRoot: false
-            runAsUser: 0
-          readinessProbe:
-            httpGet:
-              port: 15021
-              path: /healthz/ready
-          args:
+        - args:
             - proxy
             - ztunnel
           env:
@@ -10598,19 +10335,60 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
+          image: docker.io/istio/ztunnel:1.19.0
+          name: istio-proxy
+          ports:
+            - containerPort: 15020
+              name: ztunnel-stats
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: 15021
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2048Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - NET_ADMIN
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1337
+            runAsNonRoot: false
+            runAsUser: 0
           volumeMounts:
             - mountPath: /var/run/secrets/istio
               name: istiod-ca-cert
             - mountPath: /var/run/secrets/tokens
               name: istio-token
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: ztunnel
+      terminationGracePeriodSeconds: 30
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
       volumes:
         - name: istio-token
           projected:
             sources:
               - serviceAccountToken:
-                  path: istio-token
-                  expirationSeconds: 43200
                   audience: istio-ca
-        - name: istiod-ca-cert
-          configMap:
+                  expirationSeconds: 43200
+                  path: istio-token
+        - configMap:
             name: istio-ca-root-cert
+          name: istiod-ca-cert
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0

--- a/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
@@ -6,50 +6,41 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-ingressgateway-service-account
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
     operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway-service-account
+  namespace: istio-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-reader-service-account
-  namespace: istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-service-account
+  namespace: istio-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app: istiod
+    release: istio
   name: istiod
   namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istiod-service-account
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-clusterrole-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-clusterrole-istio-system
 rules:
   - apiGroups:
       - config.istio.io
@@ -79,12 +70,21 @@ rules:
       - watch
   - apiGroups:
       - networking.istio.io
+    resources:
+      - workloadentries
     verbs:
       - get
       - watch
       - list
+  - apiGroups:
+      - networking.x-k8s.io
+      - gateway.networking.k8s.io
     resources:
-      - workloadentries
+      - gateways
+    verbs:
+      - get
+      - watch
+      - list
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -143,105 +143,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-istio-system
-  labels:
-    app: istio-reader
-    release: istio
-rules:
-  - apiGroups:
-      - config.istio.io
-      - security.istio.io
-      - networking.istio.io
-      - authentication.istio.io
-      - rbac.istio.io
-    resources:
-      - '*'
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - endpoints
-      - pods
-      - services
-      - nodes
-      - replicationcontrollers
-      - namespaces
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-    resources:
-      - workloadentries
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - replicasets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceexports
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceimports
-    verbs:
-      - get
-      - watch
-      - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istiod-clusterrole-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-clusterrole-istio-system
 rules:
   - apiGroups:
       - admissionregistration.k8s.io
@@ -270,26 +175,16 @@ rules:
       - rbac.istio.io
       - telemetry.istio.io
       - extensions.istio.io
-    verbs:
-      - get
-      - watch
-      - list
     resources:
       - '*'
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
       - list
-      - update
-      - patch
-      - create
-      - delete
+  - apiGroups:
+      - networking.istio.io
     resources:
       - workloadentries
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
@@ -298,8 +193,18 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - networking.istio.io
     resources:
       - workloadentries/status
+    verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -421,25 +326,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istiod-gateway-controller-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-gateway-controller-istio-system
 rules:
   - apiGroups:
       - apps
-    verbs:
-      - get
-      - watch
-      - list
-      - update
-      - patch
-      - create
-      - delete
     resources:
       - deployments
-  - apiGroups:
-      - ""
     verbs:
       - get
       - watch
@@ -448,10 +343,10 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - ""
     resources:
       - services
-  - apiGroups:
-      - ""
     verbs:
       - get
       - watch
@@ -460,51 +355,10 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - ""
     resources:
       - serviceaccounts
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-rules:
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - mutatingwebhookconfigurations
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-      - patch
-  - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - validatingwebhookconfigurations
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - config.istio.io
-      - security.istio.io
-      - networking.istio.io
-      - authentication.istio.io
-      - rbac.istio.io
-      - telemetry.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-    resources:
-      - '*'
-  - apiGroups:
-      - networking.istio.io
     verbs:
       - get
       - watch
@@ -513,164 +367,14 @@ rules:
       - patch
       - create
       - delete
-    resources:
-      - workloadentries
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - get
-      - watch
-      - list
-      - update
-      - patch
-      - create
-      - delete
-    resources:
-      - workloadentries/status
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - nodes
-      - services
-      - namespaces
-      - endpoints
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - discovery.k8s.io
-    resources:
-      - endpointslices
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-      - ingressclasses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses/status
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - certificates.k8s.io
-    resources:
-      - certificatesigningrequests
-      - certificatesigningrequests/approval
-      - certificatesigningrequests/status
-    verbs:
-      - update
-      - create
-      - get
-      - delete
-      - watch
-  - apiGroups:
-      - certificates.k8s.io
-    resources:
-      - signers
-    resourceNames:
-      - kubernetes.io/legacy-unknown
-    verbs:
-      - approve
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
-  - apiGroups:
-      - networking.x-k8s.io
-      - gateway.networking.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - networking.x-k8s.io
-      - gateway.networking.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - update
-  - apiGroups:
-      - gateway.networking.k8s.io
-    resources:
-      - gatewayclasses
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceexports
-    verbs:
-      - get
-      - watch
-      - list
-      - create
-      - delete
-  - apiGroups:
-      - multicluster.x-k8s.io
-    resources:
-      - serviceimports
-    verbs:
-      - get
-      - watch
-      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-clusterrole-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-clusterrole-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -683,26 +387,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-istio-system
-  labels:
-    app: istio-reader
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istio-reader-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istio-reader-service-account
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istiod-clusterrole-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-clusterrole-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -715,10 +403,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istiod-gateway-controller-istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod-gateway-controller-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -726,34 +414,18 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: istiod-istio-system
-  labels:
-    app: istiod
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: istiod-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istiod-service-account
     namespace: istio-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
-  labels:
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
 rules:
   - apiGroups:
       - ""
@@ -767,18 +439,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod
+  namespace: istio-system
 rules:
   - apiGroups:
       - networking.istio.io
-    verbs:
-      - create
     resources:
       - gateways
+    verbs:
+      - create
   - apiGroups:
       - ""
     resources:
@@ -807,42 +479,15 @@ rules:
       - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: istiod-istio-system
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
-rules:
-  - apiGroups:
-      - networking.istio.io
-    verbs:
-      - create
-    resources:
-      - gateways
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - get
-      - watch
-      - list
-      - update
-      - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
-  labels:
-    release: istio
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -854,11 +499,11 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
     release: istio
+  name: istiod
+  namespace: istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -866,23 +511,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: istiod
-    namespace: istio-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: istiod-istio-system
-  namespace: istio-system
-  labels:
-    app: istiod
-    release: istio
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: istiod-istio-system
-subjects:
-  - kind: ServiceAccount
-    name: istiod-service-account
     namespace: istio-system
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -4190,7 +3818,7 @@ spec:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -4226,6 +3854,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -4302,7 +3931,7 @@ spec:
                         description: Set of TLS related options that govern the server's behavior.
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -4338,6 +3967,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -4373,10 +4003,10 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: istiooperators.install.istio.io
   labels:
     release: istio
     knative.dev/crd-install: "true"
+  name: istiooperators.install.istio.io
 spec:
   conversion:
     strategy: None
@@ -4385,10 +4015,10 @@ spec:
     kind: IstioOperator
     listKind: IstioOperatorList
     plural: istiooperators
-    singular: istiooperator
     shortNames:
       - iop
       - io
+    singular: istiooperator
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
@@ -4404,8 +4034,6 @@ spec:
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-      subresources:
-        status: {}
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -4413,6 +4041,8 @@ spec:
           x-kubernetes-preserve-unknown-fields: true
       served: true
       storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5108,7 +4738,7 @@ spec:
                       tls:
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -5144,6 +4774,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -5277,7 +4908,7 @@ spec:
                       tls:
                         properties:
                           caCertificates:
-                            description: REQUIRED if mode is `MUTUAL`.
+                            description: REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.
                             type: string
                           cipherSuites:
                             description: 'Optional: If specified, only support the specified cipher list.'
@@ -5313,6 +4944,7 @@ spec:
                               - MUTUAL
                               - AUTO_PASSTHROUGH
                               - ISTIO_MUTUAL
+                              - OPTIONAL_MUTUAL
                             type: string
                           privateKey:
                             description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
@@ -6133,6 +5765,32 @@ spec:
                             format: double
                             type: number
                         type: object
+                      mirrors:
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            percentage:
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        type: array
                       name:
                         description: The name assigned to the route for debugging purposes.
                         type: string
@@ -6194,6 +5852,16 @@ spec:
                             type: string
                           uri:
                             type: string
+                          uriRegexRewrite:
+                            description: rewrite the path portion of the URI with the specified regex.
+                            properties:
+                              match:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                              rewrite:
+                                description: The string that should replace into matching portions of original URI.
+                                type: string
+                            type: object
                         type: object
                       route:
                         description: A HTTP rule can either return a direct_response, redirect or forward (default) traffic.
@@ -6860,6 +6528,32 @@ spec:
                             format: double
                             type: number
                         type: object
+                      mirrors:
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service registry.
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  type: string
+                              type: object
+                            percentage:
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        type: array
                       name:
                         description: The name assigned to the route for debugging purposes.
                         type: string
@@ -6921,6 +6615,16 @@ spec:
                             type: string
                           uri:
                             type: string
+                          uriRegexRewrite:
+                            description: rewrite the path portion of the URI with the specified regex.
+                            properties:
+                              match:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                type: string
+                              rewrite:
+                                description: The string that should replace into matching portions of original URI.
+                                type: string
+                            type: object
                         type: object
                       route:
                         description: A HTTP rule can either return a direct_response, redirect or forward (default) traffic.
@@ -7150,6 +6854,12 @@ spec:
             spec:
               description: 'Extend the functionality provided by the Istio proxy through WebAssembly filters. See more details at: https://istio.io/docs/reference/config/proxy_extensions/wasm-plugin.html'
               properties:
+                failStrategy:
+                  description: Specifies the failure behavior for the plugin due to fatal errors.
+                  enum:
+                    - FAIL_CLOSE
+                    - FAIL_OPEN
+                  type: string
                 imagePullPolicy:
                   enum:
                     - UNSPECIFIED_POLICY
@@ -7668,17 +7378,7 @@ spec:
         status: {}
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: istio
-  namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
-    release: istio
 data:
-  meshNetworks: 'networks: {}'
   mesh: |-
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
@@ -7693,130 +7393,19 @@ data:
     enablePrometheusMerge: true
     rootNamespace: istio-system
     trustDomain: cluster.local
----
-apiVersion: v1
+  meshNetworks: 'networks: {}'
 kind: ConfigMap
 metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
   labels:
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Pilot
     release: istio
+  name: istio
+  namespace: istio-system
+---
+apiVersion: v1
 data:
-  values: |-
-    {
-      "global": {
-        "autoscalingv2API": true,
-        "caAddress": "",
-        "caName": "",
-        "certSigners": [],
-        "configCluster": false,
-        "configValidation": true,
-        "defaultNodeSelector": {},
-        "defaultPodDisruptionBudget": {
-          "enabled": true
-        },
-        "defaultResources": {
-          "requests": {
-            "cpu": "10m"
-          }
-        },
-        "enabled": true,
-        "externalIstiod": false,
-        "hub": "docker.io/istio",
-        "imagePullPolicy": "",
-        "imagePullSecrets": [],
-        "istioNamespace": "istio-system",
-        "istiod": {
-          "enableAnalysis": false
-        },
-        "jwtPolicy": "third-party-jwt",
-        "logAsJson": false,
-        "logging": {
-          "level": "default:info"
-        },
-        "meshID": "",
-        "meshNetworks": {},
-        "mountMtlsCerts": false,
-        "multiCluster": {
-          "clusterName": "",
-          "enabled": false
-        },
-        "namespace": "istio-system",
-        "network": "",
-        "omitSidecarInjectorConfigMap": false,
-        "oneNamespace": false,
-        "operatorManageWebhooks": false,
-        "pilotCertProvider": "istiod",
-        "priorityClassName": "",
-        "proxy": {
-          "autoInject": "enabled",
-          "clusterDomain": "cluster.local",
-          "componentLogLevel": "misc:error",
-          "enableCoreDump": false,
-          "excludeIPRanges": "",
-          "excludeInboundPorts": "",
-          "excludeOutboundPorts": "",
-          "image": "proxyv2",
-          "includeIPRanges": "*",
-          "includeInboundPorts": "*",
-          "includeOutboundPorts": "",
-          "logLevel": "warning",
-          "privileged": false,
-          "readinessFailureThreshold": 30,
-          "readinessInitialDelaySeconds": 1,
-          "readinessPeriodSeconds": 2,
-          "resources": {
-            "limits": {
-              "cpu": "2000m",
-              "memory": "1024Mi"
-            },
-            "requests": {
-              "cpu": "100m",
-              "memory": "128Mi"
-            }
-          },
-          "statusPort": 15020,
-          "tracer": "zipkin"
-        },
-        "proxy_init": {
-          "image": "proxyv2"
-        },
-        "remotePilotAddress": "",
-        "sds": {
-          "token": {
-            "aud": "istio-ca"
-          }
-        },
-        "sts": {
-          "servicePort": 0
-        },
-        "tag": "1.18.0",
-        "tracer": {
-          "datadog": {},
-          "lightstep": {},
-          "stackdriver": {},
-          "zipkin": {}
-        },
-        "useMCP": false,
-        "variant": ""
-      },
-      "istio_cni": {
-        "enabled": false
-      },
-      "revision": "",
-      "sidecarInjectorWebhook": {
-        "alwaysInjectSelector": [],
-        "defaultTemplates": [],
-        "enableNamespacesByDefault": false,
-        "injectedAnnotations": {},
-        "neverInjectSelector": [],
-        "rewriteAppHTTPProbe": true,
-        "templates": {}
-      }
-    }
   config: |-
     # defaultTemplates defines the default template to use for pods that do not explicitly specify a template
     defaultTemplates: [sidecar]
@@ -7855,6 +7444,7 @@ data:
             {{- end }}
           {{- end }}
         {{- end }}
+        {{ $nativeSidecar := (eq (env "ENABLE_NATIVE_SIDECARS" "false") "true") }}
         {{- $containers := list }}
         {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
         metadata:
@@ -7877,7 +7467,7 @@ data:
             {{- end }}
         {{- if .Values.istio_cni.enabled }}
             {{- if not .Values.istio_cni.chained }}
-            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}',
+            k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `default/istio-cni` }}',
             {{- end }}
             sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}",
             {{ with annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}traffic.sidecar.istio.io/includeOutboundIPRanges: "{{.}}",{{ end }}
@@ -8015,13 +7605,16 @@ data:
               runAsNonRoot: false
               runAsUser: 0
           {{ end }}
+          {{ if not $nativeSidecar }}
           containers:
+          {{ end }}
           - name: istio-proxy
           {{- if contains "/" (annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image) }}
             image: "{{ annotation .ObjectMeta `sidecar.istio.io/proxyImage` .Values.global.proxy.image }}"
           {{- else }}
             image: "{{ .ProxyImage }}"
           {{- end }}
+            {{ if $nativeSidecar }}restartPolicy: Always{{end}}
             ports:
             - containerPort: 15090
               protocol: TCP
@@ -8108,6 +7701,14 @@ data:
                 ]
             - name: ISTIO_META_APP_CONTAINERS
               value: "{{ $containers | join "," }}"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: ISTIO_META_CLUSTER_ID
               value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
             - name: ISTIO_META_NODE_NAME
@@ -8155,7 +7756,11 @@ data:
             {{- end }}
             {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
+          {{ if $nativeSidecar }}
+            startupProbe:
+          {{ else }}
             readinessProbe:
+          {{ end }}
               httpGet:
                 path: /healthz/ready
                 port: 15021
@@ -8338,10 +7943,6 @@ data:
             - name: {{ . }}
             {{- end }}
           {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
-          {{- end }}
       gateway: |
         {{- $containers := list }}
         {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
@@ -8437,6 +8038,14 @@ data:
                   {{- end}}
                 {{- end}}
                 ]
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
             - name: ISTIO_META_APP_CONTAINERS
               value: "{{ $containers | join "," }}"
             - name: ISTIO_META_CLUSTER_ID
@@ -8575,10 +8184,6 @@ data:
             {{- range .Values.global.imagePullSecrets }}
             - name: {{ . }}
             {{- end }}
-          {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
           {{- end }}
       grpc-simple: |
         metadata:
@@ -8963,10 +8568,6 @@ data:
             - name: {{ . }}
             {{- end }}
           {{- end }}
-          {{- if eq (env "ENABLE_LEGACY_FSGROUP_INJECTION" "false") "true" }}
-          securityContext:
-            fsGroup: 1337
-          {{- end }}
       waypoint: |
         apiVersion: v1
         kind: ServiceAccount
@@ -9020,7 +8621,17 @@ data:
               terminationGracePeriodSeconds: 2
               serviceAccountName: {{.ServiceAccount | quote}}
               containers:
-              - args:
+              - name: istio-proxy
+                ports:
+                - containerPort: 15021
+                  name: status-port
+                  protocol: TCP
+                - containerPort: 15090
+                  protocol: TCP
+                  name: http-envoy-prom
+                image: {{.ProxyImage}}
+                {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
+                args:
                 - proxy
                 - waypoint
                 - --domain
@@ -9082,6 +8693,14 @@ data:
                 - name: PROXY_CONFIG
                   value: |
                          {{ protoToJSON .ProxyConfig }}
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                - name: GOMAXPROCS
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
                 - name: ISTIO_META_CLUSTER_ID
                   value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
                 - name: ISTIO_META_INTERCEPTION_MODE
@@ -9097,9 +8716,6 @@ data:
                 - name: ISTIO_META_MESH_ID
                   value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
                 {{- end }}
-                image: {{.ProxyImage}}
-                {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
-                name: istio-proxy
                 resources:
                   limits:
                     cpu: "2"
@@ -9199,12 +8815,18 @@ data:
             uid: "{{.UID}}"
         spec:
           ports:
-          - name: https-hbone
-            port: 15008
+          {{- range $key, $val := .Ports }}
+          - name: {{ $val.Name | quote }}
+            port: {{ $val.Port }}
             protocol: TCP
-            appProtocol: https
+            appProtocol: {{ $val.AppProtocol }}
+          {{- end }}
           selector:
             istio.io/gateway-name: "{{.Name}}"
+          {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
+          loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
+          {{- end }}
+          type: {{ .ServiceType | quote }}
         ---
       kube-gateway: |
         apiVersion: v1
@@ -9263,6 +8885,10 @@ data:
               containers:
               - name: istio-proxy
                 image: "{{ .ProxyImage }}"
+                {{- if .Values.global.proxy.resources }}
+                resources:
+                  {{- toYaml .Values.global.proxy.resources | nindent 10 }}
+                {{- end }}
                 {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
                 securityContext:
                 {{- if .KubeVersion122 }}
@@ -9358,6 +8984,14 @@ data:
                   value: "[]"
                 - name: ISTIO_META_APP_CONTAINERS
                   value: ""
+                - name: GOMEMLIMIT
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.memory
+                - name: GOMAXPROCS
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: limits.cpu
                 - name: ISTIO_META_CLUSTER_ID
                   value: "{{ valueOrDefault .Values.global.multiCluster.clusterName .ClusterID }}"
                 - name: ISTIO_META_NODE_NAME
@@ -9366,9 +9000,9 @@ data:
                       fieldPath: spec.nodeName
                 - name: ISTIO_META_INTERCEPTION_MODE
                   value: "{{ .ProxyConfig.InterceptionMode.String }}"
-                {{- if .Values.global.network }}
+                {{- with (valueOrDefault  (index .Labels "topology.istio.io/network") .Values.global.network) }}
                 - name: ISTIO_META_NETWORK
-                  value: "{{ .Values.global.network }}"
+                  value: {{.|quote}}
                 {{- end }}
                 - name: ISTIO_META_WORKLOAD_NAME
                   value: {{.DeploymentName|quote}}
@@ -9514,11 +9148,134 @@ data:
           {{- end }}
           selector:
             istio.io/gateway-name: {{.Name}}
-          {{- if .Spec.Addresses }}
+          {{- if and (.Spec.Addresses) (eq .ServiceType "LoadBalancer") }}
           loadBalancerIP: {{ (index .Spec.Addresses 0).Value | quote}}
           {{- end }}
-          type: {{ index .Annotations "networking.istio.io/service-type" | default "LoadBalancer" | quote }}
+          type: {{ .ServiceType | quote }}
         ---
+  values: |-
+    {
+      "global": {
+        "autoscalingv2API": true,
+        "caAddress": "",
+        "caName": "",
+        "certSigners": [],
+        "configCluster": false,
+        "configValidation": true,
+        "defaultNodeSelector": {},
+        "defaultPodDisruptionBudget": {
+          "enabled": true
+        },
+        "defaultResources": {
+          "requests": {
+            "cpu": "10m"
+          }
+        },
+        "enabled": true,
+        "externalIstiod": false,
+        "hub": "docker.io/istio",
+        "imagePullPolicy": "",
+        "imagePullSecrets": [],
+        "istioNamespace": "istio-system",
+        "istiod": {
+          "enableAnalysis": false
+        },
+        "jwtPolicy": "third-party-jwt",
+        "logAsJson": false,
+        "logging": {
+          "level": "default:info"
+        },
+        "meshID": "",
+        "meshNetworks": {},
+        "mountMtlsCerts": false,
+        "multiCluster": {
+          "clusterName": "",
+          "enabled": false
+        },
+        "namespace": "istio-system",
+        "network": "",
+        "omitSidecarInjectorConfigMap": false,
+        "oneNamespace": false,
+        "operatorManageWebhooks": false,
+        "pilotCertProvider": "istiod",
+        "priorityClassName": "",
+        "proxy": {
+          "autoInject": "enabled",
+          "clusterDomain": "cluster.local",
+          "componentLogLevel": "misc:error",
+          "enableCoreDump": false,
+          "excludeIPRanges": "",
+          "excludeInboundPorts": "",
+          "excludeOutboundPorts": "",
+          "image": "proxyv2",
+          "includeIPRanges": "*",
+          "includeInboundPorts": "*",
+          "includeOutboundPorts": "",
+          "logLevel": "warning",
+          "privileged": false,
+          "readinessFailureThreshold": 30,
+          "readinessInitialDelaySeconds": 1,
+          "readinessPeriodSeconds": 2,
+          "resources": {
+            "limits": {
+              "cpu": "2000m",
+              "memory": "1024Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          },
+          "statusPort": 15020,
+          "tracer": "zipkin"
+        },
+        "proxy_init": {
+          "image": "proxyv2"
+        },
+        "remotePilotAddress": "",
+        "sds": {
+          "token": {
+            "aud": "istio-ca"
+          }
+        },
+        "sts": {
+          "servicePort": 0
+        },
+        "tag": "1.19.0",
+        "tracer": {
+          "datadog": {},
+          "lightstep": {},
+          "stackdriver": {},
+          "zipkin": {}
+        },
+        "useMCP": false,
+        "variant": ""
+      },
+      "istio_cni": {
+        "chained": true,
+        "enabled": false
+      },
+      "revision": "",
+      "sidecarInjectorWebhook": {
+        "alwaysInjectSelector": [],
+        "defaultTemplates": [],
+        "enableNamespacesByDefault": false,
+        "injectedAnnotations": {},
+        "neverInjectSelector": [],
+        "reinvocationPolicy": "Never",
+        "rewriteAppHTTPProbe": true,
+        "templates": {}
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
+  name: istio-sidecar-injector
+  namespace: istio-system
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -9632,7 +9389,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: docker.io/istio/proxyv2:1.18.0
+          image: docker.io/istio/proxyv2:1.19.0
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -9746,45 +9503,40 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istiod
+  namespace: istio-system
 spec:
+  selector:
+    matchLabels:
+      istio: pilot
   strategy:
     rollingUpdate:
       maxSurge: 100%
       maxUnavailable: 25%
-  selector:
-    matchLabels:
-      istio: pilot
   template:
     metadata:
-      labels:
-        app: istiod
-        istio.io/rev: default
-        install.operator.istio.io/owning-resource: unknown
-        sidecar.istio.io/inject: "false"
-        operator.istio.io/component: Pilot
-        istio: pilot
       annotations:
+        ambient.istio.io/redirection: disabled
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
-        ambient.istio.io/redirection: disabled
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: istiod
+        install.operator.istio.io/owning-resource: unknown
+        istio: pilot
+        istio.io/rev: default
+        operator.istio.io/component: Pilot
         sidecar.istio.io/inject: "false"
     spec:
-      serviceAccountName: istiod
-      securityContext:
-        fsGroup: 1337
       containers:
-        - name: discovery
-          image: docker.io/istio/pilot:1.18.0
-          args:
+        - args:
             - discovery
             - --monitoringAddr=:15014
             - --log_output_level=default:info
@@ -9792,20 +9544,6 @@ spec:
             - cluster.local
             - --keepaliveMaxServerConnectionAge
             - 30m
-          ports:
-            - containerPort: 8080
-              protocol: TCP
-            - containerPort: 15010
-              protocol: TCP
-            - containerPort: 15017
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 8080
-            initialDelaySeconds: 1
-            periodSeconds: 3
-            timeoutSeconds: 5
           env:
             - name: REVISION
               value: default
@@ -9832,10 +9570,6 @@ spec:
               value: /var/run/secrets/remote/config
             - name: PILOT_TRACE_SAMPLING
               value: "1"
-            - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
-              value: "true"
-            - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
-              value: "true"
             - name: ISTIOD_ADDR
               value: istiod.istio-system.svc:15012
             - name: PILOT_ENABLE_ANALYSIS
@@ -9846,37 +9580,62 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: PLATFORM
+              value: ""
+          image: docker.io/istio/pilot:1.19.0
+          name: discovery
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 15010
+              protocol: TCP
+            - containerPort: 15017
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            timeoutSeconds: 5
           resources:
             requests:
               cpu: 500m
               memory: 2048Mi
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1337
-            runAsGroup: 1337
-            runAsNonRoot: true
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
           volumeMounts:
-            - name: istio-token
-              mountPath: /var/run/secrets/tokens
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
               readOnly: true
-            - name: local-certs
-              mountPath: /var/run/secrets/istio-dns
-            - name: cacerts
-              mountPath: /etc/cacerts
+            - mountPath: /var/run/secrets/istio-dns
+              name: local-certs
+            - mountPath: /etc/cacerts
+              name: cacerts
               readOnly: true
-            - name: istio-kubeconfig
-              mountPath: /var/run/secrets/remote
+            - mountPath: /var/run/secrets/remote
+              name: istio-kubeconfig
               readOnly: true
-            - name: istio-csr-dns-cert
-              mountPath: /var/run/secrets/istiod/tls
+            - mountPath: /var/run/secrets/istiod/tls
+              name: istio-csr-dns-cert
               readOnly: true
-            - name: istio-csr-ca-configmap
-              mountPath: /var/run/secrets/istiod/ca
+            - mountPath: /var/run/secrets/istiod/ca
+              name: istio-csr-ca-configmap
               readOnly: true
+      securityContext:
+        fsGroup: 1337
+      serviceAccountName: istiod
       volumes:
         - emptyDir:
             medium: Memory
@@ -9890,40 +9649,36 @@ spec:
                   path: istio-token
         - name: cacerts
           secret:
-            secretName: cacerts
             optional: true
+            secretName: cacerts
         - name: istio-kubeconfig
           secret:
-            secretName: istio-kubeconfig
             optional: true
+            secretName: istio-kubeconfig
         - name: istio-csr-dns-cert
           secret:
+            optional: true
             secretName: istiod-tls
-            optional: true
-        - name: istio-csr-ca-configmap
-          configMap:
-            name: istio-ca-root-cert
+        - configMap:
             defaultMode: 420
+            name: istio-ca-root-cert
             optional: true
+          name: istio-csr-ca-configmap
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   annotations: null
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: IngressGateways
-spec:
-  type: LoadBalancer
-  selector:
-    app: istio-ingressgateway
     istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
   ports:
     - name: status-port
       port: 15021
@@ -9937,33 +9692,37 @@ spec:
       port: 443
       protocol: TCP
       targetPort: 8443
+  selector:
+    app: istio-ingressgateway
+    istio: ingressgateway
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: istiod
+    install.operator.istio.io/owning-resource: unknown
+    istio: pilot
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+    release: istio
   name: istiod
   namespace: istio-system
-  labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
-    app: istiod
-    istio: pilot
-    release: istio
 spec:
   ports:
-    - port: 15010
-      name: grpc-xds
+    - name: grpc-xds
+      port: 15010
       protocol: TCP
-    - port: 15012
-      name: https-dns
+    - name: https-dns
+      port: 15012
       protocol: TCP
-    - port: 443
-      name: https-webhook
+    - name: https-webhook
+      port: 443
+      protocol: TCP
       targetPort: 15017
-      protocol: TCP
-    - port: 15014
-      name: http-monitoring
+    - name: http-monitoring
+      port: 15014
       protocol: TCP
   selector:
     app: istiod
@@ -9972,41 +9731,41 @@ spec:
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
     operator.istio.io/component: Pilot
+    release: istio
+  name: istiod
+  namespace: istio-system
 spec:
   maxReplicas: 3
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 60
+          type: Utilization
+      type: Resource
   minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: istiod
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 60
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
-    istio: ingressgateway
-    release: istio
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: ingressgateway
+    istio.io/rev: default
     operator.istio.io/component: IngressGateways
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
@@ -10017,15 +9776,15 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: istiod
-  namespace: istio-system
   labels:
     app: istiod
-    istio.io/rev: default
     install.operator.istio.io/owning-resource: unknown
+    istio: pilot
+    istio.io/rev: default
     operator.istio.io/component: Pilot
     release: istio
-    istio: pilot
+  name: istiod
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
@@ -10036,35 +9795,25 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: istio-sidecar-injector
   labels:
-    istio.io/rev: default
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: Pilot
     app: sidecar-injector
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
+  name: istio-sidecar-injector
 webhooks:
-  - name: rev.namespace.sidecar-injector.istio.io
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.namespace.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio.io/rev
@@ -10079,27 +9828,28 @@ webhooks:
           operator: NotIn
           values:
             - "false"
-  - name: rev.object.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.object.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio.io/rev
@@ -10116,27 +9866,28 @@ webhooks:
           operator: In
           values:
             - default
-  - name: namespace.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: namespace.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio-injection
@@ -10149,27 +9900,28 @@ webhooks:
           operator: NotIn
           values:
             - "false"
-  - name: object.sidecar-injector.istio.io
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /inject
         port: 443
-    sideEffects: None
-    rules:
-      - operations:
-          - CREATE
-        apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        resources:
-          - pods
     failurePolicy: Fail
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: object.sidecar-injector.istio.io
     namespaceSelector:
       matchExpressions:
         - key: istio-injection
@@ -10184,44 +9936,55 @@ webhooks:
             - "true"
         - key: istio.io/rev
           operator: DoesNotExist
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - pods
+    sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: istio-validator-istio-system
   labels:
     app: istiod
-    release: istio
     istio: istiod
     istio.io/rev: default
+    release: istio
+  name: istio-validator-istio-system
 webhooks:
-  - name: rev.validation.istio.io
+  - admissionReviewVersions:
+      - v1beta1
+      - v1
     clientConfig:
       service:
         name: istiod
         namespace: istio-system
         path: /validate
-    rules:
-      - operations:
-          - CREATE
-          - UPDATE
-        apiGroups:
-          - security.istio.io
-          - networking.istio.io
-          - telemetry.istio.io
-          - extensions.istio.io
-        apiVersions:
-          - '*'
-        resources:
-          - '*'
     failurePolicy: Ignore
-    sideEffects: None
-    admissionReviewVersions:
-      - v1beta1
-      - v1
+    name: rev.validation.istio.io
     objectSelector:
       matchExpressions:
         - key: istio.io/rev
           operator: In
           values:
             - default
+    rules:
+      - apiGroups:
+          - security.istio.io
+          - networking.istio.io
+          - telemetry.istio.io
+          - extensions.istio.io
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - '*'
+    sideEffects: None


### PR DESCRIPTION
# Changes
- Bump istio manifests to v1.19.0
- We cannot bump the go-deps yet, see https://github.com/knative-extensions/net-istio/issues/1168#issuecomment-1731035128

Partially #1168 
Fixes #1177

/assign @dprotaso 
/assign @nak3 
