### PR TITLE
Bump Istio to 1.19.3

### DIFF
--- a/third_party/istio-latest/generate-manifests.sh
+++ b/third_party/istio-latest/generate-manifests.sh
@@ -16,4 +16,4 @@
 
 source "$(dirname $0)/../library.sh"
 
-generate "1.19.0" "$(dirname $0)"
+generate "1.19.3" "$(dirname $0)"

--- a/third_party/istio-latest/istio-ci-ambient/istio.yaml
+++ b/third_party/istio-latest/istio-ci-ambient/istio.yaml
@@ -9385,7 +9385,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.19.0",
+        "tag": "1.19.3",
         "tracer": {
           "datadog": {},
           "lightstep": {},
@@ -9535,7 +9535,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: docker.io/istio/proxyv2:1.19.0
+          image: docker.io/istio/proxyv2:1.19.3
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -9742,7 +9742,7 @@ spec:
                   resource: limits.cpu
             - name: PLATFORM
               value: ""
-          image: docker.io/istio/pilot:1.19.0
+          image: docker.io/istio/pilot:1.19.3
           name: discovery
           ports:
             - containerPort: 8080
@@ -10224,7 +10224,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-          image: docker.io/istio/install-cni:1.19.0
+          image: docker.io/istio/install-cni:1.19.3
           name: install-cni
           readinessProbe:
             httpGet:
@@ -10335,7 +10335,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
-          image: docker.io/istio/ztunnel:1.19.0
+          image: docker.io/istio/ztunnel:1.19.3
           name: istio-proxy
           ports:
             - containerPort: 15020

--- a/third_party/istio-latest/istio-ci-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-mesh/istio.yaml
@@ -9241,7 +9241,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.19.0",
+        "tag": "1.19.3",
         "tracer": {
           "datadog": {},
           "lightstep": {},
@@ -9389,7 +9389,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: docker.io/istio/proxyv2:1.19.0
+          image: docker.io/istio/proxyv2:1.19.3
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -9586,7 +9586,7 @@ spec:
                   resource: limits.cpu
             - name: PLATFORM
               value: ""
-          image: docker.io/istio/pilot:1.19.0
+          image: docker.io/istio/pilot:1.19.3
           name: discovery
           ports:
             - containerPort: 8080

--- a/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-ci-no-mesh/istio.yaml
@@ -9241,7 +9241,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.19.0",
+        "tag": "1.19.3",
         "tracer": {
           "datadog": {},
           "lightstep": {},
@@ -9389,7 +9389,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: docker.io/istio/proxyv2:1.19.0
+          image: docker.io/istio/proxyv2:1.19.3
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -9586,7 +9586,7 @@ spec:
                   resource: limits.cpu
             - name: PLATFORM
               value: ""
-          image: docker.io/istio/pilot:1.19.0
+          image: docker.io/istio/pilot:1.19.3
           name: discovery
           ports:
             - containerPort: 8080

--- a/third_party/istio-latest/istio-kind-ambient/istio.yaml
+++ b/third_party/istio-latest/istio-kind-ambient/istio.yaml
@@ -9385,7 +9385,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.19.0",
+        "tag": "1.19.3",
         "tracer": {
           "datadog": {},
           "lightstep": {},
@@ -9535,7 +9535,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: docker.io/istio/proxyv2:1.19.0
+          image: docker.io/istio/proxyv2:1.19.3
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -9742,7 +9742,7 @@ spec:
                   resource: limits.cpu
             - name: PLATFORM
               value: ""
-          image: docker.io/istio/pilot:1.19.0
+          image: docker.io/istio/pilot:1.19.3
           name: discovery
           ports:
             - containerPort: 8080
@@ -10224,7 +10224,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-          image: docker.io/istio/install-cni:1.19.0
+          image: docker.io/istio/install-cni:1.19.3
           name: install-cni
           readinessProbe:
             httpGet:
@@ -10335,7 +10335,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
-          image: docker.io/istio/ztunnel:1.19.0
+          image: docker.io/istio/ztunnel:1.19.3
           name: istio-proxy
           ports:
             - containerPort: 15020

--- a/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
+++ b/third_party/istio-latest/istio-kind-no-mesh/istio.yaml
@@ -9241,7 +9241,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.19.0",
+        "tag": "1.19.3",
         "tracer": {
           "datadog": {},
           "lightstep": {},
@@ -9389,7 +9389,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: docker.io/istio/proxyv2:1.19.0
+          image: docker.io/istio/proxyv2:1.19.3
           name: istio-proxy
           ports:
             - containerPort: 15021
@@ -9586,7 +9586,7 @@ spec:
                   resource: limits.cpu
             - name: PLATFORM
               value: ""
-          image: docker.io/istio/pilot:1.19.0
+          image: docker.io/istio/pilot:1.19.3
           name: discovery
           ports:
             - containerPort: 8080


### PR DESCRIPTION
This patch mumps istio manifest version to 1.19.3 which fixes [the security vulnerabilities.](https://istio.io/latest/news/releases/1.19.x/announcing-1.19.3/)