### PR TITLE
Use curl instead of wget

### DIFF
--- a/third_party/library.sh
+++ b/third_party/library.sh
@@ -67,7 +67,7 @@ function download_istio() {
 
   ISTIO_TMP=$(mktemp -d)
   pushd "$ISTIO_TMP"
-  wget --no-check-certificate "$DOWNLOAD_URL"
+  curl -LO "$DOWNLOAD_URL"
   if [ $? != 0 ]; then
     echo "Failed to download Istio release: $DOWNLOAD_URL"
     exit 1


### PR DESCRIPTION
`curl` is present by default on most systems - i ran the generate script and had to install wget

Also we use a lot of curl in serving so we can standardize on it