### PR TITLE
Shorten kind/e2e GitHub Action Names

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -1,4 +1,4 @@
-name: KinD e2e tests
+name: e2e
 
 on:
   pull_request:
@@ -13,8 +13,8 @@ defaults:
     working-directory: ./src/knative.dev/net-istio
 
 jobs:
-  e2e-tests:
-    name: e2e tests
+  test:
+    name: test
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false # Keep running if one leg fails.


### PR DESCRIPTION
Shortens

`KinD e2e tests / e2e tests (v1.27.x, ./test/conformance, latest, system-internal-tls, ambient)`
to

`e2e / test (v1.27.x, ./test/conformance, latest, system-internal-tls, ambient) `