### PR TITLE
Filter IngressTLS for visibility IngressVisibilityExternalIP 

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -143,7 +143,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 			return err
 		}
 
-		nonWildcardIngressTLS := resources.GetNonWildcardIngressTLS(ing.Spec.TLS, nonWildcardSecrets)
+		nonWildcardIngressTLS := resources.GetNonWildcardIngressTLS(ing.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP), nonWildcardSecrets)
 		ingressGateways, err = resources.MakeIngressTLSGateways(ctx, ing, nonWildcardIngressTLS, nonWildcardSecrets, r.svcLister)
 		if err != nil {
 			return err
@@ -419,7 +419,7 @@ func (r *Reconciler) reconcileDeletion(ctx context.Context, ing *v1alpha1.Ingres
 	}
 
 	errs := []error{}
-	for _, tls := range ing.Spec.TLS {
+	for _, tls := range ing.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP) {
 		nameNamespaces, err := resources.GetIngressGatewaySvcNameNamespaces(ctx)
 		if err != nil {
 			errs = append(errs, err)
@@ -542,14 +542,14 @@ func getLBStatus(gatewayServiceURL string) []v1alpha1.LoadBalancerIngressStatus 
 }
 
 func shouldReconcileTLS(ing *v1alpha1.Ingress) bool {
-	return isIngressPublic(ing) && len(ing.Spec.TLS) > 0
+	return isIngressPublic(ing) && len(ing.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP)) > 0
 }
 
 func shouldReconcileHTTPServer(ing *v1alpha1.Ingress) bool {
 	// We will create a Ingress specific HTTPServer when
 	// 1. auto TLS is enabled as in this case users want us to fully handle the TLS/HTTP behavior,
 	// 2. HTTPOption is set to Redirected as we don't have default HTTP server supporting HTTP redirection.
-	return isIngressPublic(ing) && (ing.Spec.HTTPOption == v1alpha1.HTTPOptionRedirected || len(ing.Spec.TLS) > 0)
+	return isIngressPublic(ing) && (ing.Spec.HTTPOption == v1alpha1.HTTPOptionRedirected || len(ing.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP)) > 0)
 }
 
 func isIngressPublic(ing *v1alpha1.Ingress) bool {

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -116,7 +116,7 @@ func MakeIngressTLSGateways(ctx context.Context, ing *v1alpha1.Ingress, ingressT
 	}
 	gateways := make([]*v1beta1.Gateway, len(gatewayServices))
 	for i, gatewayService := range gatewayServices {
-		servers, err := MakeTLSServers(ing, ing.Spec.TLS, gatewayService.Namespace, originSecrets)
+		servers, err := MakeTLSServers(ing, ing.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP), gatewayService.Namespace, originSecrets)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -139,7 +139,8 @@ var modifiedDefaultTLSServer = istiov1beta1.Server{
 
 var ingressSpec = v1alpha1.IngressSpec{
 	Rules: []v1alpha1.IngressRule{{
-		Hosts: []string{"host1.example.com"},
+		Hosts:      []string{"host1.example.com"},
+		Visibility: v1alpha1.IngressVisibilityExternalIP,
 	}},
 	TLS: []v1alpha1.IngressTLS{{
 		Hosts:           []string{"host1.example.com"},
@@ -294,7 +295,7 @@ func TestMakeTLSServers(t *testing.T) {
 	}}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			servers, err := MakeTLSServers(c.ci, c.ci.Spec.TLS, c.gatewayServiceNamespace, c.originSecrets)
+			servers, err := MakeTLSServers(c.ci, c.ci.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP), c.gatewayServiceNamespace, c.originSecrets)
 			if (err != nil) != c.wantErr {
 				t.Fatalf("Test: %s; MakeServers error = %v, WantErr %v", c.name, err, c.wantErr)
 			}
@@ -960,7 +961,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 			},
 		})
 		t.Run(c.name, func(t *testing.T) {
-			got, err := MakeIngressTLSGateways(ctx, c.ia, c.ia.Spec.TLS, c.originSecrets, svcLister)
+			got, err := MakeIngressTLSGateways(ctx, c.ia, c.ia.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP), c.originSecrets, svcLister)
 			if (err != nil) != c.wantErr {
 				t.Fatalf("Test: %s; MakeIngressTLSGateways error = %v, WantErr %v", c.name, err, c.wantErr)
 			}

--- a/pkg/reconciler/ingress/resources/secret.go
+++ b/pkg/reconciler/ingress/resources/secret.go
@@ -37,7 +37,7 @@ import (
 // returns a map whose key is the a secret namespace/name key and value is pointer of the secret.
 func GetSecrets(ing *v1alpha1.Ingress, secretLister corev1listers.SecretLister) (map[string]*corev1.Secret, error) {
 	secrets := map[string]*corev1.Secret{}
-	for _, tls := range ing.Spec.TLS {
+	for _, tls := range ing.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP) {
 		ref := secretKey(tls)
 		if _, ok := secrets[ref]; ok {
 			continue

--- a/pkg/reconciler/ingress/resources/secret_test.go
+++ b/pkg/reconciler/ingress/resources/secret_test.go
@@ -51,6 +51,12 @@ var (
 			Namespace: system.Namespace(),
 		},
 		Spec: v1alpha1.IngressSpec{
+			Rules: []v1alpha1.IngressRule{
+				{
+					Hosts:      []string{"example.com"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+				},
+			},
 			TLS: []v1alpha1.IngressTLS{{
 				Hosts:           []string{"example.com"},
 				SecretName:      "secret0",
@@ -90,6 +96,12 @@ func TestGetSecrets(t *testing.T) {
 		secret: &corev1.Secret{},
 		ci: &v1alpha1.Ingress{
 			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{
+					{
+						Hosts:      []string{"example.com"},
+						Visibility: v1alpha1.IngressVisibilityExternalIP,
+					},
+				},
 				TLS: []v1alpha1.IngressTLS{{
 					Hosts:           []string{"example.com"},
 					SecretName:      "no-exist-secret",


### PR DESCRIPTION
Although net-istio does not support `cluster-local-domain-tls`, enabling the feature will create additional entries in `IngressTLS`. As net-istio only expects entries for `IngressVisibilityExternalIP` visibilities, this PR filters them out to keep the existing behaviour.

# Changes
- Filter IngressTLS for visibility IngressVisibilityExternalIP

Partially https://github.com/knative/serving/issues/14624

/assign @dprotaso 
/assign @nak3 
/assign @skonto 
