### PR TITLE
Drop testing on k8s v1.26

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.26.x
         - v1.27.x
         - v1.28.x
 


### PR DESCRIPTION
# Changes
- Drop testing on k8s v1.26

Fixes #1217

/assign @dprotaso 
/assign @nak3 