### PR TITLE
Use ko label filter instead of removing KnativeCertificate yaml

### DIFF
--- a/config/700-istio-knative-certificate.yaml
+++ b/config/700-istio-knative-certificate.yaml
@@ -19,6 +19,7 @@ metadata:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
     networking.knative.dev/certificate-type: system-internal
+    knative.dev/install-knative-certificate: "true"
   name: routing-serving-certs
   namespace: istio-system
 spec:

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -69,11 +69,9 @@ function test_setup() {
 
   ${istio_dir}/install-istio.sh ${istio_profile} || return 1
 
-  # Remove Knative Certificate as we are running without Serving CRs
-  rm -f config/700-istio-knative-certificate.yaml
-
   echo ">> Bringing up net-istio Ingress Controller"
-  ko apply --platform=linux/amd64 -f config/ || return 1
+  # Do not install Knative Certificate for e2e tests, as we are running without Serving CRs
+  ko apply --platform=linux/amd64 -l knative.dev/install-knative-certificate!=true -f config/ || return 1
 
   if [[ -f "${istio_dir}/${istio_profile}/config-istio.yaml" ]]; then
     kubectl apply -f "${istio_dir}/${istio_profile}/config-istio.yaml"


### PR DESCRIPTION
# Changes
- Followup for https://github.com/knative-extensions/net-istio/pull/1221
- Removing the file results in the `KnativeCertificate` not being in the release manifest: https://github.com/knative/serving/pull/14610/commits/a42001549c5dbe9a57c2ebd6ecc30db467408629#diff-845c4618eefc690238aaab455d8f1b79ffd5c30eec4c2f5b50da9b57017b39a8L588
- Use ko label filter instead of removing KnativeCertificate yaml

/assign @skonto 
