### PR TITLE
Host cluster-local-domain-tls on cluster-local gateway with SNI

### DIFF
--- a/config/203-local-gateway.yaml
+++ b/config/203-local-gateway.yaml
@@ -57,4 +57,4 @@ spec:
       targetPort: 8081
     - name: https
       port: 443
-      targetPort: 8443
+      targetPort: 8444

--- a/config/203-local-gateway.yaml
+++ b/config/203-local-gateway.yaml
@@ -55,3 +55,6 @@ spec:
     - name: http2
       port: 80
       targetPort: 8081
+    - name: https
+      port: 443
+      targetPort: 8443

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -182,13 +182,17 @@ var (
 		"gateway." + config.KnativeIngressGateway: newDomainInternal,
 		"gateway.knative-test-gateway":            originDomainInternal,
 	}
-	ingressGateway = map[v1alpha1.IngressVisibility]sets.Set[string]{
+	externalIngressGateway = map[v1alpha1.IngressVisibility]sets.Set[string]{
 		v1alpha1.IngressVisibilityExternalIP: sets.New(config.KnativeIngressGateway),
+	}
+	localIngressGateway = map[v1alpha1.IngressVisibility]sets.Set[string]{
+		v1alpha1.IngressVisibilityClusterLocal: sets.New(config.KnativeLocalGateway),
 	}
 	gateways = map[v1alpha1.IngressVisibility]sets.Set[string]{
 		v1alpha1.IngressVisibilityExternalIP: sets.New[string]("knative-test-gateway", config.KnativeIngressGateway),
 	}
-	perIngressGatewayName = resources.GatewayName(ingressWithTLS("reconciling-ingress", ingressTLS), ingressService)
+	externalIngressTLSGatewayName = resources.GatewayName(ingressWithTLS("reconciling-ingress", externalIngressTLS), v1alpha1.IngressVisibilityExternalIP, ingressService)
+	localIngressTLSGatewayName    = resources.GatewayName(ingressWithTLS("reconciling-ingress", localIngressTLS), v1alpha1.IngressVisibilityClusterLocal, ingressService)
 )
 
 var (
@@ -228,15 +232,37 @@ var (
 		Visibility: v1alpha1.IngressVisibilityClusterLocal,
 	}}
 
-	ingressTLS = []v1alpha1.IngressTLS{{
+	externalIngressTLS = []v1alpha1.IngressTLS{{
 		Hosts:           []string{"host-tls.example.com"},
 		SecretName:      "secret0",
 		SecretNamespace: "istio-system",
 	}}
 
-	// The gateway server according to ingressTLS.
-	ingressTLSServer = &istiov1beta1.Server{
+	localIngressTLS = []v1alpha1.IngressTLS{{
+		Hosts:           []string{"host-tls.test-ns.svc.cluster.local"},
+		SecretName:      "secret0",
+		SecretNamespace: "istio-system",
+	}}
+
+	// The gateway server according to externalIngressTLS.
+	externalIngressTLSServer = &istiov1beta1.Server{
 		Hosts: []string{"host-tls.example.com"},
+		Port: &istiov1beta1.Port{
+			Name:     "test-ns/reconciling-ingress:0",
+			Number:   443,
+			Protocol: "HTTPS",
+		},
+		Tls: &istiov1beta1.ServerTLSSettings{
+			Mode:               istiov1beta1.ServerTLSSettings_SIMPLE,
+			ServerCertificate:  "tls.crt",
+			PrivateKey:         "tls.key",
+			CredentialName:     "secret0",
+			MinProtocolVersion: istiov1beta1.ServerTLSSettings_TLSV1_2,
+		},
+	}
+
+	localIngressTLSServer = &istiov1beta1.Server{
+		Hosts: []string{"host-tls.test-ns.svc.cluster.local"},
 		Port: &istiov1beta1.Port{
 			Name:     "test-ns/reconciling-ingress:0",
 			Number:   443,
@@ -272,7 +298,7 @@ var (
 		},
 	}
 
-	// The gateway server irrelevant to ingressTLS.
+	// The gateway server irrelevant to externalIngressTLS.
 	irrelevantServer = &istiov1beta1.Server{
 		Hosts: []string{"host-tls.example.com", "host-tls.test-ns.svc.cluster.local"},
 		Port: &istiov1beta1.Port{
@@ -712,24 +738,24 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		Name:                    "create Ingress Gateway to match newly created Ingress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			ingressWithTLS("reconciling-ingress", ingressTLS),
+			ingressWithTLS("reconciling-ingress", externalIngressTLS),
 			originSecret("istio-system", "secret0"),
 			ingressService,
 		},
 		WantCreates: []runtime.Object{
 			// The newly created per-Ingress Gateway.
-			gateway(perIngressGatewayName, testNS, []*istiov1beta1.Server{ingressTLSServer, ingressHTTPServer},
-				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS, []*istiov1beta1.Server{externalIngressTLSServer, ingressHTTPServer},
+				withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
-			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), ingressGateway),
-			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", externalIngressTLS)), externalIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", externalIngressTLS)), makeGatewayMap([]string{"test-ns/" + externalIngressTLSGatewayName}, nil)),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("reconciling-ingress", ingressFinalizer),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithTLSAndStatus("reconciling-ingress",
-				ingressTLS,
+				externalIngressTLS,
 				v1alpha1.IngressStatus{
 					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
 						Ingress: []v1alpha1.LoadBalancerIngressStatus{
@@ -770,25 +796,25 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		Name:                    "Update Ingress Gateway to match Ingress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			ingressWithTLS("reconciling-ingress", ingressTLS),
+			ingressWithTLS("reconciling-ingress", externalIngressTLS),
 			// The existing Ingress gateway does not have HTTPS server.
-			gateway(perIngressGatewayName, testNS,
-				[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 			originSecret("istio-system", "secret0"),
 			ingressService,
 		},
 		WantCreates: []runtime.Object{
-			gateway(perIngressGatewayName, testNS,
-				[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 
-			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), ingressGateway),
-			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", externalIngressTLS)), externalIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", externalIngressTLS)), makeGatewayMap([]string{"test-ns/" + externalIngressTLSGatewayName}, nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: gateway(perIngressGatewayName, testNS,
-				[]*istiov1beta1.Server{ingressTLSServer, ingressHTTPServer}, withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			Object: gateway(externalIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{externalIngressTLSServer, ingressHTTPServer}, withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 		}},
 		WantPatches: []clientgotesting.PatchActionImpl{
@@ -796,7 +822,7 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithTLSAndStatus("reconciling-ingress",
-				ingressTLS,
+				externalIngressTLS,
 				v1alpha1.IngressStatus{
 					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
 						Ingress: []v1alpha1.LoadBalancerIngressStatus{
@@ -837,7 +863,7 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		Name:                    "new Ingress using wildcard certificate",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			ingressWithTLS("reconciling-ingress", ingressTLS),
+			ingressWithTLS("reconciling-ingress", externalIngressTLS),
 			wildcardCert,
 			ingressService,
 		},
@@ -845,20 +871,20 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 			wildcardGateway(resources.WildcardGatewayName(wildcardCert.Name, ingressService.Namespace, ingressService.Name), "istio-system",
 				[]*istiov1beta1.Server{wildcardTLSServer}, selector),
 			// The newly created per-Ingress Gateway.
-			gateway(perIngressGatewayName, testNS, []*istiov1beta1.Server{ingressHTTPServer},
-				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS, []*istiov1beta1.Server{ingressHTTPServer},
+				withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 
-			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), ingressGateway),
-			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLS)), makeGatewayMap([]string{"istio-system/" + resources.WildcardGatewayName(wildcardCert.Name, ingressService.Namespace, ingressService.Name),
-				"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", externalIngressTLS)), externalIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", externalIngressTLS)), makeGatewayMap([]string{"istio-system/" + resources.WildcardGatewayName(wildcardCert.Name, ingressService.Namespace, ingressService.Name),
+				"test-ns/" + externalIngressTLSGatewayName}, nil)),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("reconciling-ingress", ingressFinalizer),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithTLSAndStatus("reconciling-ingress",
-				ingressTLS,
+				externalIngressTLS,
 				v1alpha1.IngressStatus{
 					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
 						Ingress: []v1alpha1.LoadBalancerIngressStatus{
@@ -898,7 +924,7 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 	}, {
 		Name: "No preinstalled Ingress service",
 		Objects: []runtime.Object{
-			ingressWithTLS("reconciling-ingress", ingressTLS),
+			ingressWithTLS("reconciling-ingress", externalIngressTLS),
 			originSecret("istio-system", "secret0"),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
@@ -906,7 +932,7 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithTLSAndStatus("reconciling-ingress",
-				ingressTLS,
+				externalIngressTLS,
 				v1alpha1.IngressStatus{
 					Status: duckv1.Status{
 						Conditions: duckv1.Conditions{{
@@ -939,13 +965,13 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		Name:                    "delete Ingress",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			ingressWithFinalizers("reconciling-ingress", ingressTLS, []string{ingressFinalizer}, &deletionTime),
+			ingressWithFinalizers("reconciling-ingress", externalIngressTLS, []string{ingressFinalizer}, &deletionTime),
 			// ingressHTTPRedirectServer should not be deleted when deleting ingress related TLS server..
-			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, ingressTLSServer, ingressHTTPRedirectServer}),
+			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, externalIngressTLSServer, ingressHTTPRedirectServer}),
 		},
 		WantCreates: []runtime.Object{
 			// The creation of gateways are triggered when setting up the test.
-			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, ingressTLSServer, ingressHTTPRedirectServer}),
+			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, externalIngressTLSServer, ingressHTTPRedirectServer}),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{ingressHTTPRedirectServer, irrelevantServer}),
@@ -963,14 +989,14 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		Name:                    "delete ingress with leftover secrets",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			ingressWithFinalizers("reconciling-ingress", ingressTLS, []string{ingressFinalizer}, &deletionTime),
+			ingressWithFinalizers("reconciling-ingress", externalIngressTLS, []string{ingressFinalizer}, &deletionTime),
 			// ingressHTTPRedirectServer should not be deleted when deleting ingress related TLS server..
-			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, ingressTLSServer, ingressHTTPRedirectServer}),
+			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, externalIngressTLSServer, ingressHTTPRedirectServer}),
 			targetSecret("istio-system", "targetSecret", resources.MakeTargetSecretLabels("secret0", "istio-system")),
 		},
 		WantCreates: []runtime.Object{
 			// The creation of gateways are triggered when setting up the test.
-			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, ingressTLSServer, ingressHTTPRedirectServer}),
+			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, externalIngressTLSServer, ingressHTTPRedirectServer}),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{ingressHTTPRedirectServer, irrelevantServer}),
@@ -1004,13 +1030,13 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		},
 		WantCreates: []runtime.Object{
 			// The newly created per-Ingress Gateway.
-			gateway(perIngressGatewayName, testNS,
-				[]*istiov1beta1.Server{withCredentialName(deepCopy(ingressTLSServer), targetSecretName), ingressHTTPServer},
-				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{withCredentialName(deepCopy(externalIngressTLSServer), targetSecretName), ingressHTTPServer},
+				withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 
-			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), ingressGateway),
-			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), externalIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), makeGatewayMap([]string{"test-ns/" + externalIngressTLSGatewayName}, nil)),
 
 			// The secret copy under istio-system.
 			targetSecret("istio-system", targetSecretName, map[string]string{
@@ -1069,9 +1095,9 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 			ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving")),
 
 			// The newly created per-Ingress Gateway.
-			gateway(perIngressGatewayName, testNS,
-				[]*istiov1beta1.Server{withCredentialName(deepCopy(ingressTLSServer), targetSecretName), ingressHTTPServer},
-				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{withCredentialName(deepCopy(externalIngressTLSServer), targetSecretName), ingressHTTPServer},
+				withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 			ingressService,
 
@@ -1094,13 +1120,13 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 			},
 		},
 		WantCreates: []runtime.Object{
-			gateway(perIngressGatewayName, testNS,
-				[]*istiov1beta1.Server{withCredentialName(deepCopy(ingressTLSServer), targetSecretName), ingressHTTPServer},
-				withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+			gateway(externalIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{withCredentialName(deepCopy(externalIngressTLSServer), targetSecretName), ingressHTTPServer},
+				withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 				withLabels(gwLabels), withSelector(selector)),
 
-			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), ingressGateway),
-			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), makeGatewayMap([]string{"test-ns/" + perIngressGatewayName}, nil)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), externalIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", ingressTLSWithSecretNamespace("knative-serving"))), makeGatewayMap([]string{"test-ns/" + externalIngressTLSGatewayName}, nil)),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: &corev1.Secret{
@@ -1161,18 +1187,18 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 		Key:     "test-ns/reconciling-ingress",
 		CmpOpts: defaultCmpOptsList,
 	}, {
-		Name:                    "Reconcile with autoTLS but cluster local visibilty, mesh only",
+		Name:                    "Reconcile with external-domain-tls but cluster local visibility, mesh only",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			ingressWithTLSClusterLocal("reconciling-ingress", ingressTLS),
+			ingressWithTLSClusterLocal("reconciling-ingress", externalIngressTLS),
 			originSecret("istio-system", "secret0"),
 		},
 		WantCreates: []runtime.Object{
-			resources.MakeMeshVirtualService(insertProbe(ingressWithTLSClusterLocal("reconciling-ingress", ingressTLS)), ingressGateway),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLSClusterLocal("reconciling-ingress", externalIngressTLS)), externalIngressGateway),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: ingressWithTLSAndStatusClusterLocal("reconciling-ingress",
-				ingressTLS,
+				externalIngressTLS,
 				v1alpha1.IngressStatus{
 					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
 						Ingress: []v1alpha1.LoadBalancerIngressStatus{
@@ -1254,6 +1280,226 @@ func TestReconcile_ExternalDomainTLS(t *testing.T) {
 						Network: &netconfig.Config{
 							HTTPProtocol:      netconfig.HTTPDisabled,
 							ExternalDomainTLS: true,
+						},
+					},
+				},
+			})
+	}))
+}
+
+func TestReconcile_ClusterLocalDomainTLS(t *testing.T) {
+	table := TableTest{{
+		Name:                    "create local TLS gateway for an ingress with cluster-local TLS",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			ingressWithTLS("reconciling-ingress", localIngressTLS),
+			originSecret("istio-system", "secret0"),
+			ingressService,
+		},
+		WantCreates: []runtime.Object{
+			gateway(localIngressTLSGatewayName, testNS, []*istiov1beta1.Server{localIngressTLSServer},
+				withOwnerRef(ingressWithTLS("reconciling-ingress", localIngressTLS)),
+				withLabels(gwLabels), withSelector(selector)),
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", localIngressTLS)), localIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", localIngressTLS)),
+				makeGatewayMap([]string{"knative-testing/" + config.KnativeIngressGateway}, []string{"knative-testing/" + config.KnativeLocalGateway, "test-ns/" + localIngressTLSGatewayName})),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddFinalizerAction("reconciling-ingress", ingressFinalizer),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: ingressWithTLSAndStatus("reconciling-ingress",
+				localIngressTLS,
+				v1alpha1.IngressStatus{
+					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system")},
+						},
+					},
+					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{
+								DomainInternal: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
+								MeshOnly:       false,
+							},
+						},
+					},
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:     v1alpha1.IngressConditionLoadBalancerReady,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}, {
+							Type:     v1alpha1.IngressConditionNetworkConfigured,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}, {
+							Type:     v1alpha1.IngressConditionReady,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}},
+					},
+				},
+			),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "reconciling-ingress"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-mesh"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-ingress"),
+		},
+		Key:     "test-ns/reconciling-ingress",
+		CmpOpts: defaultCmpOptsList,
+	}, {
+		Name:                    "update local TLS gateway for an ingress with cluster-local TLS",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			ingressWithTLS("reconciling-ingress", localIngressTLS),
+			// The existing Ingress gateway does not have HTTPS server.
+			gateway(localIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", localIngressTLS)),
+				withLabels(gwLabels), withSelector(selector)),
+			originSecret("istio-system", "secret0"),
+			ingressService,
+		},
+		WantCreates: []runtime.Object{
+			gateway(localIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", localIngressTLS)),
+				withLabels(gwLabels), withSelector(selector)),
+
+			resources.MakeMeshVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", localIngressTLS)), localIngressGateway),
+			resources.MakeIngressVirtualService(insertProbe(ingressWithTLS("reconciling-ingress", localIngressTLS)),
+				makeGatewayMap([]string{"knative-testing/" + config.KnativeIngressGateway}, []string{"knative-testing/" + config.KnativeLocalGateway, "test-ns/" + localIngressTLSGatewayName})),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: gateway(localIngressTLSGatewayName, testNS,
+				[]*istiov1beta1.Server{localIngressTLSServer}, withOwnerRef(ingressWithTLS("reconciling-ingress", localIngressTLS)),
+				withLabels(gwLabels), withSelector(selector)),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddFinalizerAction("reconciling-ingress", ingressFinalizer),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: ingressWithTLSAndStatus("reconciling-ingress",
+				localIngressTLS,
+				v1alpha1.IngressStatus{
+					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{DomainInternal: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system")},
+						},
+					},
+					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
+						Ingress: []v1alpha1.LoadBalancerIngressStatus{
+							{
+								DomainInternal: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
+								MeshOnly:       false,
+							},
+						},
+					},
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:     v1alpha1.IngressConditionLoadBalancerReady,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}, {
+							Type:     v1alpha1.IngressConditionNetworkConfigured,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}, {
+							Type:     v1alpha1.IngressConditionReady,
+							Status:   corev1.ConditionTrue,
+							Severity: apis.ConditionSeverityError,
+						}},
+					},
+				},
+			),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "reconciling-ingress"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-mesh"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-ingress"),
+		},
+		Key:     "test-ns/reconciling-ingress",
+		CmpOpts: defaultCmpOptsList,
+	}, {
+		Name:                    "delete an ingress with cluster-local TLS with leftover secrets",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			ingressWithFinalizers("reconciling-ingress", localIngressTLS, []string{ingressFinalizer}, &deletionTime),
+			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer}),
+			gateway(config.KnativeLocalGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, localIngressTLSServer}),
+			targetSecret("istio-system", "targetSecret", resources.MakeTargetSecretLabels("secret0", "istio-system")),
+		},
+		WantCreates: []runtime.Object{
+			// The creation of gateways are triggered when setting up the test.
+			gateway(config.KnativeIngressGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer}),
+			gateway(config.KnativeLocalGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer, localIngressTLSServer}),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: gateway(config.KnativeLocalGateway, system.Namespace(), []*istiov1beta1.Server{irrelevantServer}),
+		}},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddFinalizerAction("reconciling-ingress", ""),
+		},
+		WantDeletes: []clientgotesting.DeleteActionImpl{{
+			ActionImpl: clientgotesting.ActionImpl{
+				Namespace: "istio-system",
+				Verb:      "delete",
+				Resource:  corev1.SchemeGroupVersion.WithResource("secrets"),
+			},
+			Name: "targetSecret",
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Gateway %s/%s", system.Namespace(), config.KnativeLocalGateway),
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "reconciling-ingress"),
+		},
+		Key:     "test-ns/reconciling-ingress",
+		CmpOpts: defaultCmpOptsList,
+	}}
+	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
+
+		// As we use a customized resource name for Gateway CRD (i.e. `gateways`), not the one
+		// originally generated by kubernetes code generator (i.e. `gatewaies`), we have to
+		// explicitly create gateways when setting up the test per suggestion
+		// https://github.com/knative/serving/blob/a6852fc3b6cdce72b99c5d578dd64f2e03dabb8b/vendor/k8s.io/client-go/testing/fixture.go#L292
+		gateways := getGatewaysFromObjects(listers.GetIstioObjects())
+		for _, gateway := range gateways {
+			fakeistioclient.Get(ctx).NetworkingV1beta1().Gateways(gateway.Namespace).Create(ctx, gateway, metav1.CreateOptions{})
+		}
+
+		r := &Reconciler{
+			kubeclient:            kubeclient.Get(ctx),
+			istioClientSet:        istioclient.Get(ctx),
+			virtualServiceLister:  listers.GetVirtualServiceLister(),
+			destinationRuleLister: listers.GetDestinationRuleLister(),
+			gatewayLister:         listers.GetGatewayLister(),
+			secretLister:          listers.GetSecretLister(),
+			svcLister:             listers.GetK8sServiceLister(),
+			tracker:               &NullTracker{},
+			statusManager: &fakestatusmanager.FakeStatusManager{
+				FakeIsReady: func(ctx context.Context, ing *v1alpha1.Ingress) (bool, error) {
+					return true, nil
+				},
+			},
+		}
+
+		return ingressreconciler.NewReconciler(ctx, logging.FromContext(ctx), fakenetworkingclient.Get(ctx),
+			listers.GetIngressLister(), controller.GetEventRecorder(ctx), r, netconfig.IstioIngressClassName, controller.Options{
+				ConfigStore: &testConfigStore{
+					config: &config.Config{
+						Istio: &config.Istio{
+							IngressGateways: []config.Gateway{{
+								Namespace:  system.Namespace(),
+								Name:       config.KnativeIngressGateway,
+								ServiceURL: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
+							}},
+							LocalGateways: []config.Gateway{{
+								Namespace:  system.Namespace(),
+								Name:       config.KnativeLocalGateway,
+								ServiceURL: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system"),
+							}},
+						},
+						Network: &netconfig.Config{
+							ClusterLocalDomainTLS: netconfig.EncryptionEnabled,
 						},
 					},
 				},
@@ -1351,7 +1597,7 @@ func deepCopy(server *istiov1beta1.Server) *istiov1beta1.Server {
 
 func ingressTLSWithSecretNamespace(namespace string) []v1alpha1.IngressTLS {
 	result := []v1alpha1.IngressTLS{}
-	for _, tls := range ingressTLS {
+	for _, tls := range externalIngressTLS {
 		tls.SecretNamespace = namespace
 		result = append(result, tls)
 	}
@@ -1673,8 +1919,8 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 	h.OnUpdate(&istioClient.Fake, "gateways", func(obj runtime.Object) HookResult {
 		createdGateway := obj.(*v1beta1.Gateway)
 		// The expected gateway should include the Istio TLS server.
-		expectedGateway := gateway(perIngressGatewayName, testNS,
-			[]*istiov1beta1.Server{ingressTLSServer, ingressHTTPServer}, withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+		expectedGateway := gateway(externalIngressTLSGatewayName, testNS,
+			[]*istiov1beta1.Server{externalIngressTLSServer, ingressHTTPServer}, withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 			withLabels(gwLabels), withSelector(selector))
 		if diff := cmp.Diff(createdGateway, expectedGateway, protocmp.Transform()); diff != "" {
 			t.Log("Unexpected Gateway (-want, +got):", diff)
@@ -1703,7 +1949,7 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 	grp.Go(func() error { return ctrl.RunContext(ctx, 1) })
 
 	ingress := ingressWithTLSAndStatus("reconciling-ingress",
-		ingressTLS,
+		externalIngressTLS,
 		v1alpha1.IngressStatus{
 			PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
 				Ingress: []v1alpha1.LoadBalancerIngressStatus{
@@ -1737,8 +1983,8 @@ func TestGlobalResyncOnUpdateNetwork(t *testing.T) {
 
 	// Create an Ingress gateway
 	ingressGatewayClient := istioClient.NetworkingV1beta1().Gateways(testNS)
-	ingressGateway := gateway(perIngressGatewayName, testNS,
-		[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", ingressTLS)),
+	ingressGateway := gateway(externalIngressTLSGatewayName, testNS,
+		[]*istiov1beta1.Server{}, withOwnerRef(ingressWithTLS("reconciling-ingress", externalIngressTLS)),
 		withLabels(gwLabels), withSelector(selector))
 	if _, err := ingressGatewayClient.Create(ctx, ingressGateway, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Error creating gateway:", err)

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -164,7 +164,7 @@ var (
 		Hosts: []string{"*.example.com"},
 		Port: &istiov1beta1.Port{
 			Name:     "https",
-			Number:   443,
+			Number:   resources.ExternalGatewayHTTPSPort,
 			Protocol: "HTTPS",
 		},
 		Tls: &istiov1beta1.ServerTLSSettings{
@@ -249,7 +249,7 @@ var (
 		Hosts: []string{"host-tls.example.com"},
 		Port: &istiov1beta1.Port{
 			Name:     "test-ns/reconciling-ingress:0",
-			Number:   443,
+			Number:   resources.ExternalGatewayHTTPSPort,
 			Protocol: "HTTPS",
 		},
 		Tls: &istiov1beta1.ServerTLSSettings{
@@ -265,7 +265,7 @@ var (
 		Hosts: []string{"host-tls.test-ns.svc.cluster.local"},
 		Port: &istiov1beta1.Port{
 			Name:     "test-ns/reconciling-ingress:0",
-			Number:   443,
+			Number:   resources.ClusterLocalGatewayHTTPSPort,
 			Protocol: "HTTPS",
 		},
 		Tls: &istiov1beta1.ServerTLSSettings{
@@ -281,7 +281,7 @@ var (
 		Hosts: []string{"host-tls.example.com"},
 		Port: &istiov1beta1.Port{
 			Name:     "http-server",
-			Number:   80,
+			Number:   resources.GatewayHTTPPort,
 			Protocol: "HTTP",
 		},
 	}
@@ -290,7 +290,7 @@ var (
 		Hosts: []string{"*"},
 		Port: &istiov1beta1.Port{
 			Name:     "http-server",
-			Number:   80,
+			Number:   resources.GatewayHTTPPort,
 			Protocol: "HTTP",
 		},
 		Tls: &istiov1beta1.ServerTLSSettings{
@@ -303,7 +303,7 @@ var (
 		Hosts: []string{"host-tls.example.com", "host-tls.test-ns.svc.cluster.local"},
 		Port: &istiov1beta1.Port{
 			Name:     "test:0",
-			Number:   443,
+			Number:   resources.ExternalGatewayHTTPSPort,
 			Protocol: "HTTPS",
 		},
 		Tls: &istiov1beta1.ServerTLSSettings{
@@ -318,7 +318,7 @@ var (
 		Hosts: []string{"*"},
 		Port: &istiov1beta1.Port{
 			Name:     "http-server",
-			Number:   80,
+			Number:   resources.GatewayHTTPPort,
 			Protocol: "HTTP",
 		},
 	}

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -80,7 +80,7 @@ var servers = []*istiov1beta1.Server{{
 	Hosts: []string{"host1.example.com"},
 	Port: &istiov1beta1.Port{
 		Name:     "test-ns/ingress:0",
-		Number:   443,
+		Number:   ExternalGatewayHTTPSPort,
 		Protocol: "HTTPS",
 	},
 	Tls: &istiov1beta1.ServerTLSSettings{
@@ -92,7 +92,7 @@ var servers = []*istiov1beta1.Server{{
 	Hosts: []string{"host2.example.com"},
 	Port: &istiov1beta1.Port{
 		Name:     "test-ns/non-ingress:0",
-		Number:   443,
+		Number:   ExternalGatewayHTTPSPort,
 		Protocol: "HTTPS",
 	},
 	Tls: &istiov1beta1.ServerTLSSettings{
@@ -106,7 +106,7 @@ var httpServer = istiov1beta1.Server{
 	Hosts: []string{"*"},
 	Port: &istiov1beta1.Port{
 		Name:     httpServerPortName,
-		Number:   80,
+		Number:   GatewayHTTPPort,
 		Protocol: "HTTP",
 	},
 }
@@ -127,7 +127,7 @@ var modifiedDefaultTLSServer = istiov1beta1.Server{
 	Hosts: []string{"added.by.user.example.com"},
 	Port: &istiov1beta1.Port{
 		Name:     "https",
-		Number:   443,
+		Number:   ExternalGatewayHTTPSPort,
 		Protocol: "HTTPS",
 	},
 	Tls: &istiov1beta1.ServerTLSSettings{
@@ -183,7 +183,7 @@ func TestGetServers(t *testing.T) {
 		Hosts: []string{"host1.example.com"},
 		Port: &istiov1beta1.Port{
 			Name:     "test-ns/ingress:0",
-			Number:   443,
+			Number:   ExternalGatewayHTTPSPort,
 			Protocol: "HTTPS",
 		},
 		Tls: &istiov1beta1.ServerTLSSettings{
@@ -206,7 +206,7 @@ func TestGetHTTPServer(t *testing.T) {
 		Hosts: []string{"*"},
 		Port: &istiov1beta1.Port{
 			Name:     httpServerPortName,
-			Number:   80,
+			Number:   GatewayHTTPPort,
 			Protocol: "HTTP",
 		},
 	}
@@ -233,7 +233,7 @@ func TestMakeTLSServers(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -254,7 +254,7 @@ func TestMakeTLSServers(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -275,7 +275,7 @@ func TestMakeTLSServers(t *testing.T) {
 			Port: &istiov1beta1.Port{
 				// port name is created with <namespace>/<name>
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -295,7 +295,7 @@ func TestMakeTLSServers(t *testing.T) {
 	}}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			servers, err := MakeTLSServers(c.ci, c.ci.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP), c.gatewayServiceNamespace, c.originSecrets)
+			servers, err := MakeTLSServers(c.ci, v1alpha1.IngressVisibilityExternalIP, c.ci.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP), c.gatewayServiceNamespace, c.originSecrets)
 			if (err != nil) != c.wantErr {
 				t.Fatalf("Test: %s; MakeServers error = %v, WantErr %v", c.name, err, c.wantErr)
 			}
@@ -322,7 +322,7 @@ func TestMakeHTTPServer(t *testing.T) {
 			Hosts: []string{"*"},
 			Port: &istiov1beta1.Port{
 				Name:     httpServerPortName,
-				Number:   80,
+				Number:   GatewayHTTPPort,
 				Protocol: "HTTP",
 			},
 		},
@@ -333,7 +333,7 @@ func TestMakeHTTPServer(t *testing.T) {
 			Hosts: []string{"*"},
 			Port: &istiov1beta1.Port{
 				Name:     httpServerPortName,
-				Number:   80,
+				Number:   GatewayHTTPPort,
 				Protocol: "HTTP",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -364,7 +364,7 @@ func TestUpdateGateway(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -377,7 +377,7 @@ func TestUpdateGateway(t *testing.T) {
 			Hosts: []string{"host-new.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -394,7 +394,7 @@ func TestUpdateGateway(t *testing.T) {
 					Hosts: []string{"host-new.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "test-ns/ingress:0",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -406,7 +406,7 @@ func TestUpdateGateway(t *testing.T) {
 					Hosts: []string{"host2.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "test-ns/non-ingress:0",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -423,7 +423,7 @@ func TestUpdateGateway(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -441,7 +441,7 @@ func TestUpdateGateway(t *testing.T) {
 					Hosts: []string{"host2.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "test-ns/non-ingress:0",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -460,7 +460,7 @@ func TestUpdateGateway(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -472,7 +472,7 @@ func TestUpdateGateway(t *testing.T) {
 			Hosts: []string{"host2.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/non-ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -491,7 +491,7 @@ func TestUpdateGateway(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "test-ns/ingress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -509,7 +509,7 @@ func TestUpdateGateway(t *testing.T) {
 					Hosts: []string{"host1.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "test-ns/ingress:0",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -528,7 +528,7 @@ func TestUpdateGateway(t *testing.T) {
 			Hosts: []string{"host1.example.com"},
 			Port: &istiov1beta1.Port{
 				Name:     "clusteringress:0",
-				Number:   443,
+				Number:   ExternalGatewayHTTPSPort,
 				Protocol: "HTTPS",
 			},
 			Tls: &istiov1beta1.ServerTLSSettings{
@@ -545,7 +545,7 @@ func TestUpdateGateway(t *testing.T) {
 						Hosts: []string{"host1.example.com"},
 						Port: &istiov1beta1.Port{
 							Name:     "clusteringress:0",
-							Number:   443,
+							Number:   ExternalGatewayHTTPSPort,
 							Protocol: "HTTPS",
 						},
 						Tls: &istiov1beta1.ServerTLSSettings{
@@ -601,7 +601,7 @@ func TestMakeWildcardGateways(t *testing.T) {
 					Hosts: []string{"*.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "https",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -638,7 +638,7 @@ func TestMakeWildcardGateways(t *testing.T) {
 					Hosts: []string{"*.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "https",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -834,7 +834,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 					Hosts: []string{"host1.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "test-ns/ingress:0",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -877,7 +877,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 					Hosts: []string{"host1.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "test-ns/ingress:0",
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -923,7 +923,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 					Hosts: []string{"host1.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     "test-ns/ingress:0",
-						Number:   443,
+						Number:   ClusterLocalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{
@@ -966,7 +966,7 @@ func TestMakeIngressTLSGateways(t *testing.T) {
 					Hosts: []string{"host1.example.com"},
 					Port: &istiov1beta1.Port{
 						Name:     fmt.Sprintf("test-ns/%d:0", adler32.Checksum([]byte("ingress.com"))),
-						Number:   443,
+						Number:   ExternalGatewayHTTPSPort,
 						Protocol: "HTTPS",
 					},
 					Tls: &istiov1beta1.ServerTLSSettings{

--- a/pkg/reconciler/ingress/resources/secret.go
+++ b/pkg/reconciler/ingress/resources/secret.go
@@ -33,11 +33,11 @@ import (
 	"knative.dev/pkg/tracker"
 )
 
-// GetSecrets gets the all of the secrets referenced by the given Ingress, and
-// returns a map whose key is the a secret namespace/name key and value is pointer of the secret.
-func GetSecrets(ing *v1alpha1.Ingress, secretLister corev1listers.SecretLister) (map[string]*corev1.Secret, error) {
+// GetSecrets gets the all the secrets referenced by the given Ingress and visibility.
+// Returns a map whose key is the secret namespace/name key and value is pointer of the secret.
+func GetSecrets(ing *v1alpha1.Ingress, visibility v1alpha1.IngressVisibility, secretLister corev1listers.SecretLister) (map[string]*corev1.Secret, error) {
 	secrets := map[string]*corev1.Secret{}
-	for _, tls := range ing.GetIngressTLSForVisibility(v1alpha1.IngressVisibilityExternalIP) {
+	for _, tls := range ing.GetIngressTLSForVisibility(visibility) {
 		ref := secretKey(tls)
 		if _, ok := secrets[ref]; ok {
 			continue
@@ -72,7 +72,7 @@ func MakeSecrets(ctx context.Context, originSecrets map[string]*corev1.Secret, a
 	return secrets, nil
 }
 
-// MakeWildcardSecrets copies wildcard certificates from origin namespace to the namespace of gateway servicess so they could
+// MakeWildcardSecrets copies wildcard certificates from origin namespace to the namespace of gateway services, so they can be
 // consumed by Istio ingress.
 func MakeWildcardSecrets(ctx context.Context, originWildcardCerts map[string]*corev1.Secret) ([]*corev1.Secret, error) {
 	nameNamespaces, err := GetIngressGatewaySvcNameNamespaces(ctx)

--- a/pkg/reconciler/ingress/resources/secret_test.go
+++ b/pkg/reconciler/ingress/resources/secret_test.go
@@ -114,7 +114,7 @@ func TestGetSecrets(t *testing.T) {
 	for _, c := range cases {
 		createSecret(c.secret)
 		t.Run(c.name, func(t *testing.T) {
-			secrets, err := GetSecrets(c.ci, secretClient.Lister())
+			secrets, err := GetSecrets(c.ci, v1alpha1.IngressVisibilityExternalIP, secretClient.Lister())
 			if (err != nil) != c.wantErr {
 				t.Fatalf("Test: %s; GetSecrets error = %v, WantErr %v", c.name, err, c.wantErr)
 			}


### PR DESCRIPTION
# Changes
- Add cluster-local https servers when `cluster-local-domain-tls` is enabled and a KSVC exists
- Uses SNI to host multiple certificates for all cluster-local domain Knative Services

/kind enhancement

Fixes https://github.com/knative/serving/issues/14374

**Release Note**

```release-note
net-istio now hosts an additional gateway with TLS for each Knative Service when `cluster-local-domain-tls` is enabled. Note: this is an experimental alpha-feature.
```

**Docs**

Will be done once the features is complete
