### PR TITLE
drop k8s 1.27 from kind testing

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.27.x
         - v1.28.x
         - v1.29.x
 


### PR DESCRIPTION
# Changes

- drop k8s v1.27 from kind testing

PS: Bump of client libraries will happen in https://github.com/knative/pkg/issues/2958
