### PR TITLE
bump e2e cluster version to 1.28

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -17,7 +17,7 @@
 source $(dirname $0)/e2e-common.sh
 
 # Script entry point.
-initialize $@  --skip-istio-addon
+initialize "$@" --skip-istio-addon --cluster-version=1.28
 
 # TODO Re-enable conformance tests for mesh when everything's been fixed
 # https://github.com/knative-sandbox/net-istio/issues/584

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -17,7 +17,7 @@
 source $(dirname $0)/e2e-common.sh
 
 # Script entry point.
-initialize "$@" --skip-istio-addon --cluster-version=1.28
+initialize "$@" --cluster-version=1.28
 
 # TODO Re-enable conformance tests for mesh when everything's been fixed
 # https://github.com/knative-sandbox/net-istio/issues/584


### PR DESCRIPTION
## Changes

- specify cluster version to 1.28 in e2e test scripts

Fixes #1269 
