### PR TITLE
drop custom header for readiness and liveness probe

### DIFF
--- a/config/500-webhook-deployment.yaml
+++ b/config/500-webhook-deployment.yaml
@@ -85,18 +85,12 @@ spec:
           httpGet:
             scheme: HTTPS
             port: 8443
-            httpHeaders:
-              - name: k-kubelet-probe
-                value: "webhook"
           failureThreshold: 3
         livenessProbe:
           periodSeconds: 1
           httpGet:
             scheme: HTTPS
             port: 8443
-            httpHeaders:
-              - name: k-kubelet-probe
-                value: "webhook"
           failureThreshold: 6
           initialDelaySeconds: 20
 


### PR DESCRIPTION

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- drop custom header `k-kubelet-probe` for readiness and liveness probe

Part of https://github.com/knative/serving/issues/14981