### PR TITLE
Add missing common labels on kcert

### DIFF
--- a/config/700-istio-knative-certificate.yaml
+++ b/config/700-istio-knative-certificate.yaml
@@ -18,6 +18,10 @@ metadata:
   annotations:
     networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
   labels:
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
+    networking.knative.dev/ingress-provider: istio
     networking.knative.dev/certificate-type: system-internal
     knative.dev/install-knative-certificate: "true"
   name: routing-serving-certs


### PR DESCRIPTION
# Changes
- Add missing common labels on kcert
- Without these, the operator does not properly select these YAMLs

/assign @skonto 

/cherry-pick release-1.14