### PR TITLE
Remove useless if

### DIFF
--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -137,9 +137,6 @@ func MakeExternalIngressGateways(ctx context.Context, ing *v1alpha1.Ingress, ser
 	}
 	gateways := make([]*v1beta1.Gateway, len(gatewayServices))
 	for i, gatewayService := range gatewayServices {
-		if err != nil {
-			return nil, err
-		}
 		gateways[i] = makeIngressGateway(ing, v1alpha1.IngressVisibilityExternalIP, gatewayService.Spec.Selector, servers, gatewayService)
 	}
 	return gateways, nil


### PR DESCRIPTION
# Changes

Pull request [Support Gateway Selection using Ingress Labels #1250](https://github.com/knative-extensions/net-istio/pull/1250) removed the call to `GetIngressGatewaySvcNameNamespaces` but left the now useless error check.

/kind cleanup


