### PR TITLE
preserve appropriate header matches when creating the virtualservice

### DIFF
--- a/pkg/reconciler/ingress/resources/virtual_service.go
+++ b/pkg/reconciler/ingress/resources/virtual_service.go
@@ -260,16 +260,14 @@ func makeMatch(host, path string, headers map[string]v1alpha1.HeaderMatch, gatew
 		}
 	}
 
+	match.Headers = make(map[string]*istiov1beta1.StringMatch, len(headers))
 	for k, v := range headers {
-		match.Headers = map[string]*istiov1beta1.StringMatch{
-			k: {
-				MatchType: &istiov1beta1.StringMatch_Exact{
-					Exact: v.Exact,
-				},
+		match.Headers[k] = &istiov1beta1.StringMatch{
+			MatchType: &istiov1beta1.StringMatch_Exact{
+				Exact: v.Exact,
 			},
 		}
 	}
-
 	return match
 }
 

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -212,7 +212,6 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 }
 
 func TestMakeVirtualServicesSpec_CorrectGateways(t *testing.T) {
-
 	tests := []struct {
 		name             string
 		ingress          *v1alpha1.Ingress
@@ -640,6 +639,9 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 			"my-header": {
 				Exact: "my-header-value",
 			},
+			"my-second-header": {
+				Exact: "my-second-header-value",
+			},
 		},
 		Splits: []v1alpha1.IngressBackendSplit{{
 			IngressBackend: v1alpha1.IngressBackend{
@@ -664,6 +666,11 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 						Exact: "my-header-value",
 					},
 				},
+				"my-second-header": {
+					MatchType: &istiov1beta1.StringMatch_Exact{
+						Exact: "my-second-header-value",
+					},
+				},
 			},
 		}, {
 			Gateways: []string{"gateway-1"},
@@ -674,6 +681,11 @@ func TestMakeVirtualServiceRoute_Vanilla(t *testing.T) {
 				"my-header": {
 					MatchType: &istiov1beta1.StringMatch_Exact{
 						Exact: "my-header-value",
+					},
+				},
+				"my-second-header": {
+					MatchType: &istiov1beta1.StringMatch_Exact{
+						Exact: "my-second-header-value",
 					},
 				},
 			},


### PR DESCRIPTION



## Changes

- 🐞  Properly propagate route header matching rules to the virtual service

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes: https://github.com/knative-extensions/net-istio/issues/847 https://github.com/knative-extensions/net-istio/issues/1313

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Properly propagate route header matching rules to the virtual service
```
