### PR TITLE
Bump Kind and k8s version

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.28.x
         - v1.29.x
+        - v1.30.x
 
         test-suite:
         - ./test/conformance

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.29.x
         - v1.30.x
+        - v1.31.x
 
         test-suite:
         - ./test/conformance

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -37,7 +37,7 @@ jobs:
     - uses: knative/actions/setup-go@main
     - uses: ko-build/setup-ko@v0.6
     - uses: actions/checkout@v4
-    - uses: chainguard-dev/actions/setup-kind@1f79ee3c1d554f67a5344933e2cadfa4b58d300d
+    - uses: chainguard-dev/actions/setup-kind@main
       id: kind
       with:
         k8s-version: ${{ matrix.k8s-version }}

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -17,7 +17,7 @@
 source $(dirname $0)/e2e-common.sh
 
 # Script entry point.
-initialize "$@" --cluster-version=1.29
+initialize "$@" --cluster-version=1.30
 
 # TODO Re-enable conformance tests for mesh when everything's been fixed
 # https://github.com/knative-sandbox/net-istio/issues/584

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -17,7 +17,7 @@
 source $(dirname $0)/e2e-common.sh
 
 # Script entry point.
-initialize "$@" --cluster-version=1.28
+initialize "$@" --cluster-version=1.29
 
 # TODO Re-enable conformance tests for mesh when everything's been fixed
 # https://github.com/knative-sandbox/net-istio/issues/584


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Similar to https://github.com/knative-extensions/net-istio/pull/1270 and https://github.com/knative-extensions/net-istio/pull/1170
- We need it for 1.17 and now tests on PRs fail due to the fact that Chainguard action dropped support 1.28.

