### PR TITLE
Pin Chainguard version

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -37,7 +37,7 @@ jobs:
     - uses: knative/actions/setup-go@main
     - uses: ko-build/setup-ko@v0.6
     - uses: actions/checkout@v4
-    - uses: chainguard-dev/actions/setup-kind@main
+    - uses: chainguard-dev/actions/setup-kind@1f79ee3c1d554f67a5344933e2cadfa4b58d300d
       id: kind
       with:
         k8s-version: ${{ matrix.k8s-version }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- #1387 tests fail. Chainguard dropped support for 1.28.  We can always merge now and revert in #1388 later., or go directly for #1388.