### PR TITLE
Expose PROBE_MAX_RETRY_DELAY_SECONDS configuration with default 30

### DIFF
--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -69,6 +69,9 @@ spec:
         - name: METRICS_DOMAIN
           value: knative.dev/net-istio
 
+        - name: PROBE_MAX_RETRY_DELAY_SECONDS
+          value: "30"
+
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true


### PR DESCRIPTION
# Changes

Changing this to a lower value improves the time it takes to provision a new or updated KService on large clusters. See https://github.com/knative/networking/pull/1001 for more information.

/kind performance

**Release Note**

```release-note
You can now change the environment variable PROBE_MAX_RETRY_DELAY_SECONDS to a lower value (default is 30) to improve provisioning time of KServices in larger clusters.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>

```docs

```
-->
