### PR TITLE
[release-1.16] Move codegen script to new kube_codegen.sh

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -35,22 +35,26 @@ ${KNATIVE_CODEGEN_PKG}/hack/generate-knative.sh "injection" \
   "networking:v1beta1" \
   --go-header-file ${REPO_ROOT_DIR}/hack/boilerplate/boilerplate.go.txt
 
+source "${CODEGEN_PKG}/kube_codegen.sh"
+
 group "Kubernetes Codegen"
 
 # Generate our own client for istio (otherwise injection won't work)
-${CODEGEN_PKG}/generate-groups.sh "client,informer,lister" \
-  knative.dev/net-istio/pkg/client/istio istio.io/client-go/pkg/apis \
-  "networking:v1beta1" \
-  --go-header-file ${REPO_ROOT_DIR}/hack/boilerplate/boilerplate.go.txt
+kube::codegen::gen_client \
+  --boilerplate "${REPO_ROOT_DIR}/hack/boilerplate/boilerplate.go.txt" \
+  --output-dir "${REPO_ROOT_DIR}/pkg/client/istio" \
+  --output-pkg "knative.dev/net-istio/pkg/client/istio" \
+  --one-input-api "networking" \
+  --with-watch \
+  "${REPO_ROOT_DIR}/vendor/istio.io/client-go/pkg/apis"
 
 group "Deepcopy Gen"
 
-# Depends on generate-groups.sh to install bin/deepcopy-gen
-${GOPATH}/bin/deepcopy-gen \
-  -O zz_generated.deepcopy \
-  --go-header-file ${REPO_ROOT_DIR}/hack/boilerplate/boilerplate.go.txt \
-  -i knative.dev/net-istio/pkg/reconciler/ingress/config \
-  -i knative.dev/net-istio/pkg/defaults
+kube::codegen::gen_helpers \
+  --boilerplate "${REPO_ROOT_DIR}/hack/boilerplate/boilerplate.go.txt" \
+  --extra-peer-dir "reconciler/ingress/config" \
+  --extra-peer-dir "defaults" \
+  "${REPO_ROOT_DIR}/pkg"
 
 group "Update deps post-codegen"
 # Make sure our dependencies are up-to-date

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -17,7 +17,7 @@
 source $(dirname $0)/e2e-common.sh
 
 # Script entry point.
-initialize "$@" --cluster-version=1.28
+initialize "$@" --cluster-version=1.29
 
 # TODO Re-enable conformance tests for mesh when everything's been fixed
 # https://github.com/knative-sandbox/net-istio/issues/584


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- [release-1.16] Move codegen script to new kube_codegen.sh

PTAL, this is a usual codegen refactor to make sure `release-1.16` codegen scripts work with kube_codegen.sh stuff. Later release branch and main is OK. 
 
/cc @skonto @dprotaso 

