### PR TITLE
adjust linter and ci k8s version

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.31.x
         - v1.32.x
+        - v1.33.x
 
         test-suite:
         - ./test/conformance

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -141,6 +141,10 @@ linters:
   disable:
     - errcheck
   settings:
+    staticcheck:
+      checks:
+      - all
+      - "-QF1008" # Disable https://staticcheck.dev/docs/checks/#QF1008
     gocritic:
       disabled-checks:
         - exitAfterDefer

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -180,7 +180,7 @@ linters:
     rules:
       - linters:
           - staticcheck
-        text: corev1.Endpoint.* is deprecated
+        text: v1.Endpoint.* is deprecated
       - linters:
           - gosec
           - noctx

--- a/pkg/reconciler/ingress/resources/gateway.go
+++ b/pkg/reconciler/ingress/resources/gateway.go
@@ -312,10 +312,10 @@ func MakeTLSServers(ing *v1alpha1.Ingress, visibility v1alpha1.IngressVisibility
 	servers := make([]*istiov1beta1.Server, len(ingressTLS))
 
 	var port uint32
-	switch {
-	case visibility == v1alpha1.IngressVisibilityExternalIP:
+	switch visibility {
+	case v1alpha1.IngressVisibilityExternalIP:
 		port = ExternalGatewayHTTPSPort
-	case visibility == v1alpha1.IngressVisibilityClusterLocal:
+	case v1alpha1.IngressVisibilityClusterLocal:
 		port = ClusterLocalGatewayHTTPSPort
 	default:
 		return nil, fmt.Errorf("invalid ingress visibility: %v", visibility)

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -82,7 +82,7 @@ func MakeFactory(ctor Ctor) rtesting.Factory {
 		// Set up our Controller from the fakes.
 		c := ctor(ctx, &ls, configmap.NewStaticWatcher())
 		// Update the context with the stuff we decorated it with.
-		r.Ctx = ctx //nolint:fatcontext
+		r.Ctx = ctx
 
 		// The Reconciler won't do any work until it becomes the leader.
 		if la, ok := c.(reconciler.LeaderAware); ok {


### PR DESCRIPTION
- bump kind e2e testing to v1.32 & 1.33
- adjust error message in linter warning
- linter fixes
